### PR TITLE
refactor: Remove FCM clustering, introduce `ThreeOptTSP`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,6 @@ dependencies = [
     "kmodes>=0.12.2",
     "scikit-learn>=1.7.2",
     "scipy>=1.16",
-    "fuzzy-c-means==1.7.2"
 ]
 
 [project.optional-dependencies]

--- a/src/optimizers/combinatorial/mtsp.py
+++ b/src/optimizers/combinatorial/mtsp.py
@@ -2,7 +2,6 @@ from dataclasses import dataclass
 from typing import Literal
 
 import numpy as np
-from fcmeans import FCM
 from sklearn.cluster import KMeans, SpectralClustering
 
 from .base import CombinatoricsResult
@@ -112,13 +111,14 @@ class AntColonyMTSP:
             return clusters
         elif self.config.clustering_method == "FCM":
             # Perform the fuzzy c-means clustering
-            fcm = FCM(n_clusters=self.config.n_clusters)
-            fcm.fit(self.city_locations)
-            cluster_labels = fcm.predict(self.city_locations)
-            clusters: list[list[int]] = [[] for _ in range(self.config.n_clusters)]
-            for i, label in enumerate(cluster_labels):
-                clusters[label].append(i)
-            return clusters
+            # fcm = FCM(n_clusters=self.config.n_clusters)
+            # fcm.fit(self.city_locations)
+            # cluster_labels = fcm.predict(self.city_locations)
+            # clusters: list[list[int]] = [[] for _ in range(self.config.n_clusters)]
+            # for i, label in enumerate(cluster_labels):
+            #     clusters[label].append(i)
+            # return clusters
+            raise NotImplementedError("FCM package is unreliable")
         elif self.config.clustering_method == "spectral":
             sc = SpectralClustering(
                 n_clusters=self.config.n_clusters, assign_labels="discretize"

--- a/tests/test_combinatorics.py
+++ b/tests/test_combinatorics.py
@@ -14,6 +14,7 @@ from optimizers.combinatorial.tsp import (
     ConvexHullTSPConfig,
     TwoOptTSPConfig,
     TwoOptTSP,
+    ThreeOptTSP,
 )
 from optimizers.core.types import AF, AI
 from optimizers.plot import plot_convergence
@@ -145,7 +146,7 @@ def test_nn_tsp():
     topt_config2 = TwoOptTSPConfig(
         name="2opt TSP", back_to_start=True, nearest_neighbors=5
     )
-    topt_optimizer2 = TwoOptTSP(
+    topt_optimizer2 = ThreeOptTSP(
         topt_config2,
         initial_route=result.optimal_path,
         initial_value=result.optimal_value,


### PR DESCRIPTION
- Improve local search setup
- Mark FCM-based clustering as unreliable, remove associated dependencies, and update tests.
- Add `ThreeOptTSP` class with 3-opt local search algorithm for TSP.
- Refactor `TwoOptTSP` to improve local search setup and stopping criteria.