### PR TITLE
perf(1/6): plan + performance report + Cython analysis

### DIFF
--- a/CYTHON_ANALYSIS.md
+++ b/CYTHON_ANALYSIS.md
@@ -1,0 +1,169 @@
+# Analysis: Compiled `.pyx` (Cython) Modules for the Optimizers Library
+
+**Question:** should this library adopt Cython (`.pyx`) compiled extensions for performance?
+
+**Short answer:** For most hot loops, **numba is the better tool** and it is *already a
+dependency* — it delivers the same order-of-magnitude speedup with zero build/packaging
+cost. Cython earns its keep in a **narrow but real** set of cases: (1) `nogil` kernels that
+enable *true* multi-threaded parallelism (directly serving your multi-threading goal),
+(2) shipping a compiled artifact so end users don't pay JIT warm-up, and (3) kernels that
+mix Python objects with tight numeric loops where numba's nopython mode is awkward. This
+document maps where each applies and what the cost is.
+
+---
+
+## 1. Where the time actually goes (recap)
+
+The profiled hot paths are all **tight scalar loops over numpy arrays**:
+
+- Continuous ACO `run_ants` — per-ant, per-variable sampling loop (`continuous/aco.py`).
+- Continuous PSO `run_particles` — per-dimension velocity/position update (`continuous/pso.py`).
+- Combinatorial tour construction, `check_path_distance`, `delta_tau`, 2-opt/3-opt
+  (`combinatorial/base.py`, `strategy.py`, `aco.py`).
+- The truncated-normal sampler (addressed in PR2 without any compilation — pure scipy call fix).
+
+None of these need Python object semantics inside the loop; they operate on `float64`/`int64`
+arrays. That is precisely the profile where **both** numba and Cython excel, and where the
+choice between them is about *tooling*, not capability.
+
+---
+
+## 2. Cython vs. numba for this codebase
+
+| Dimension | numba (`@njit`) | Cython (`.pyx`) |
+|-----------|-----------------|-----------------|
+| Already a dependency? | **Yes** (`pyproject.toml`) | No — adds a build-time dep |
+| Build step / C toolchain | None (JIT at runtime) | **Required** — `cythonize`, C compiler, per-platform wheels |
+| Distribution | Pure-Python wheel | Needs compiled wheels per OS/arch (cibuildwheel) or sdist + compiler on user machines |
+| First-call cost | JIT warm-up (100 ms–2 s), amortized by `cache=True` | **None** — compiled ahead of time |
+| Speedup on scalar array loops | ~10–100× (matches C) | ~10–100× (is C) |
+| True multi-thread (`nogil`) | `nopython` + `parallel=True`/`prange` releases GIL | `nogil` blocks + `prange` (OpenMP) — **most explicit control** |
+| Debugging | Harder (JIT); good error messages now | Standard C tooling; `cython -a` HTML annotation is excellent |
+| Mixed Python-object + numeric | Poor (nopython is strict) | **Good** — can drop to `object` locally |
+| Maintenance surface | Low (decorate a function) | Higher (`.pyx` + build config + wheels) |
+
+**Consequence:** numba covers items #5, #6, #7, #10, #13 in the report at essentially no
+project cost, and PR4/PR6 will use it. Cython is only worth introducing where it does
+something numba can't do as cleanly.
+
+---
+
+## 3. Where Cython specifically wins here
+
+### 3a. `nogil` kernels for real thread-level parallelism (aligns with your multi-threading goal)
+
+Your project defaults to `joblib_prefer="threads"`, but the current worker bodies are pure
+Python, so the **GIL serializes them** — threads add overhead without parallelism (report
+#11). A Cython kernel marked `nogil` (or a numba `@njit(nogil=True)` kernel) lets several
+threads run the *same* compiled inner loop truly concurrently, **without pickling any data**
+— which is the cheapest possible answer to "don't replicate the large fixed dataset to each
+worker" (report #2). No process pool, no serialization, shared memory by construction.
+
+Illustrative `.pyx` for the ACO per-generation ant batch (schematic):
+
+```cython
+# ants.pyx
+# cython: boundscheck=False, wraparound=False, cdivision=True
+import numpy as np
+cimport numpy as cnp
+from cython.parallel cimport prange
+
+def run_ants_batch(double[:, ::1] archive,       # fixed-ish per generation, shared
+                   double[::1] cp_j,             # precomputed CDF
+                   double[:, ::1] out,           # (n_ants, n_vars) preallocated
+                   int n_ants, int n_vars) nogil:  # <-- no GIL held
+    cdef int a, i
+    for a in prange(n_ants, schedule='dynamic'):   # OpenMP threads, real parallel
+        for i in range(n_vars):
+            out[a, i] = _sample_variable(archive, cp_j, i)
+```
+
+This is the strongest Cython argument for *this* library: it turns the existing (but
+currently ineffective) thread backend into genuine multicore execution with **zero data
+copying**, which processes-based parallelism can never fully avoid. numba's
+`@njit(parallel=True, nogil=True)` achieves the same and stays dependency-free — so this is
+a genuine numba-vs-Cython toss-up, decided by whether you also want 3b/3c.
+
+**Caveat:** the *user's goal function* is still Python and holds the GIL. `nogil`
+parallelism only helps the parts of the inner loop that are pure numeric (sampling,
+distance, pheromone update, 2-opt deltas). It shines most for combinatorial local search
+(2-opt/3-opt, NN) where the whole kernel is numeric and the objective is an array reduction.
+
+### 3b. Ahead-of-time compilation — no JIT warm-up
+
+numba pays a one-time compile per kernel per process. With `processes` backends, **each
+worker re-JITs** (unless the `NUMBA_CACHE_DIR` on-disk cache is warm and shared). For
+short-lived solves or many small parallel processes, that warm-up can rival the useful work.
+Cython artifacts are compiled once at build time and impose **no** per-process cost — a real
+edge when you fan out many worker processes for short jobs.
+
+### 3c. Kernels that straddle Python objects and numeric code
+
+`InputVariable` is a Python class hierarchy; the sampling loop calls virtual methods
+(`variable.random_value(...)`). numba can't see through that. Two paths:
+- **Data-oriented refactor** (preferred, and numba-friendly): flatten variable metadata into
+  arrays (`lower[]`, `upper[]`, `is_discrete[]`, category tables) and pass those to a
+  compiled kernel. Works for *both* numba and Cython.
+- If you want to keep the object model but still compile the hot arithmetic, Cython's ability
+  to drop to `object` for the dispatch while keeping `cdef double` locals is more ergonomic
+  than fighting numba's nopython constraints.
+
+---
+
+## 4. Concrete `.pyx` candidates, ranked
+
+| Candidate | File today | Why Cython/compiled | numba enough? |
+|-----------|-----------|---------------------|:-------------:|
+| 2-opt / 3-opt local search | `combinatorial/strategy.py`, `ga.py` | Fully numeric O(n²)/O(n³) scalar loops; ideal `nogil`/`prange` | **numba fine** |
+| `check_path_distance`, `delta_tau` | `combinatorial/base.py`, `aco.py` | Tiny numeric kernels called millions of times | **numba fine** |
+| ACO ant-batch sampler | `continuous/aco.py` + `variables.py` | Benefits from `nogil` threading + no-copy shared archive | numba fine *after* data-oriented refactor |
+| Truncated-normal sampler | `continuous/variables.py` | Hot, but PR2 fixes it with a plain scipy `ndtri` call | **neither needed** |
+| PSO velocity/position update | `continuous/pso.py` | Already vectorizable in pure numpy | **plain numpy** |
+
+**Reading:** the only place Cython offers something numba doesn't is the `nogil`/no-copy
+threading story (3a) and warm-up elimination (3b) — and those benefit the **combinatorial
+local-search kernels** most, because they are 100% numeric.
+
+---
+
+## 5. Build & packaging cost (the real downside)
+
+Adopting Cython means:
+
+- `pyproject.toml` build-system gains `Cython` and `numpy` build requirements; a `setup.py`
+  with `cythonize([...])` and `numpy.get_include()`.
+- CI must build **per-platform wheels** (`cibuildwheel` across linux/macos/windows × CPython
+  versions) or ship an sdist that requires a C compiler on the user's machine — a support
+  burden for a library "used heavily for various applications."
+- OpenMP (`prange`) adds a `-fopenmp` link flag and a libgomp runtime dependency, which is
+  fiddly on macOS (needs `libomp` via brew).
+- Source no longer "just runs" from a checkout without a build step; `pip install -e .`
+  triggers compilation.
+
+numba imposes **none** of these. That asymmetry is the crux of the recommendation.
+
+---
+
+## 6. Recommendation
+
+1. **Do the numba/numpy work first** (PR4, PR6). It captures the large majority of the
+   available speedup with no build/packaging cost, and it's already a dependency.
+2. **Hold Cython in reserve for one targeted use case:** if, after PR5, thread-based
+   parallelism with a large shared read-only dataset is the dominant deployment pattern,
+   introduce a single small compiled extension for the **combinatorial local-search kernels**
+   (2-opt/3-opt) as `nogil`/`prange` `.pyx`. Prototype the *same* kernels with
+   `@njit(parallel=True, nogil=True, cache=True)` first — if numba hits the target, **skip
+   Cython** and avoid the packaging tax entirely.
+3. **Enabler regardless of tool:** refactor `InputVariable` metadata into flat arrays
+   (`lower`, `upper`, discrete category tables) so the sampling kernel is compilable by
+   *either* backend. This is the highest-leverage structural change and is tool-agnostic.
+4. **Free-threaded CPython (3.13t):** as no-GIL builds mature, `nogil` compiled kernels
+   (Cython *or* numba) become the cleanest path to multicore scaling with zero pickling —
+   worth revisiting then. `sample.py` already probes `sys._is_gil_enabled()`, so the codebase
+   is forward-looking here.
+
+**Bottom line:** Cython is a *conditional yes* — valuable only for `nogil` combinatorial
+kernels under a shared-memory threading deployment, and only if numba's parallel `nogil`
+mode proves insufficient in benchmarking. For everything else in this library, numba +
+vectorized numpy is the correct, lower-cost choice. The stacked PRs therefore use
+numba/numpy; a Cython extension is scoped as an optional follow-up gated on a benchmark.

--- a/PERFORMANCE_REPORT.md
+++ b/PERFORMANCE_REPORT.md
@@ -1,0 +1,247 @@
+# Operation "Improve Performance A Lot" — Findings & Ranked Action Plan
+
+**Repository:** `optimizers`  **Date:** 2026-07-10
+**Target hardware:** Intel Core i7-1185G7 (4C/8T), 16 GB RAM — all benchmarks sized to fit.
+**Environment:** measured inside the project `.venv` (numpy 2.4.4, scipy 1.17.1, numba 0.65.1, joblib 1.5.3, Python 3.13).
+
+---
+
+## TL;DR — the headline
+
+Profiling the continuous **ACO** solver (9 vars, pop 50, 25 gens, single worker) shows it spends **7.5 s of 7.9 s** inside `run_ants`, and **~4.8 s of that (≈60% of total runtime) is scipy building *documentation strings* for a `truncnorm` object that is re-created on every single variable sample.** This is pure waste — no math, just `_construct_doc` / `docformat` / `splitlines`.
+
+Replacing the frozen-distribution call with a direct inverse-CDF sample is a **measured 177× speedup on the sampling primitive** and should cut end-to-end ACO time by **~5–8×** with zero behavioral change. This one change (Rank #1) is the biggest single win in the codebase and is a ~15-line edit.
+
+The rest of the report ranks 14 further changes, including the multiprocessing "copy fixed data once" architecture you flagged.
+
+---
+
+## How to read the ranking
+
+Each item is scored on **Impact** (how much wall-clock it saves), **Effort** (dev cost/risk), and **Scope** (which algorithms benefit). Do them roughly top-to-bottom; items 1–4 are high-impact *and* low-effort and should land first.
+
+| # | Change | Impact | Effort | Scope |
+|---|--------|:------:|:------:|-------|
+| 1 | Kill per-sample `truncnorm` object creation | ★★★★★ | XS | ACO, GA, all continuous |
+| 2 | Send fixed data to workers **once** (persistent pool / memmap) | ★★★★☆ | M | ACO/PSO/GA (processes) |
+| 3 | Bound the solution archive to `archive_size` | ★★★★☆ | S | all continuous |
+| 4 | Reuse the global RNG instead of `np.random.default_rng()` per call | ★★★☆☆ | XS | all continuous |
+| 5 | Vectorize ACO `run_ants` across ants & precompute the CDF | ★★★★☆ | M | continuous ACO |
+| 6 | Precompute `eta**beta` / `tau**alpha` in combinatorial ACO | ★★★★★ | S | combinatorial ACO/MST |
+| 7 | Stop rebuilding the GA archive with `vstack` inside the loop | ★★★★☆ | S | combinatorial GA |
+| 8 | Replace FCM's BFGS with closed-form alternating updates | ★★★★☆ | M | clustering (FCM) |
+| 9 | `@njit` the iVAT path-max double loop | ★★★★☆ | S | VAT/iVAT |
+| 10 | Vectorize `check_path_distance` & `delta_tau` (numba) | ★★★☆☆ | S | combinatorial |
+| 11 | Choose threads vs processes correctly + document it | ★★★☆☆ | S | all |
+| 12 | Remove redundant `sort()`/`deduplicate()` passes per generation | ★★★☆☆ | S | all continuous |
+| 13 | `@njit` the local-search kernels (2-opt / 3-opt / NN) | ★★★☆☆ | M | combinatorial |
+| 14 | Trim per-eval overhead in `bump_eval` (`time.time()` every call) | ★★☆☆☆ | XS | all |
+| 15 | Vectorize discrete `random_value` (`np.unique` per sample) | ★★★☆☆ | S | discrete vars |
+
+---
+
+## The changes in detail
+
+### 1. Kill per-sample `truncnorm` object creation — the big one
+**Files:** `src/optimizers/continuous/variables.py:106-129` (`__get_truncated_normal`, `random_value`)
+
+`InputContinuousVariable.random_value` calls `truncnorm(a, b, loc, scale).rvs()` **once per variable, per ant, per generation**. Each call constructs a *fresh frozen distribution object*, and scipy eagerly builds the object's docstring (`_construct_doc` → `docformat` → millions of `str.splitlines`). The actual random draw is a rounding error next to the string formatting.
+
+**Evidence (measured on your hardware):**
+```
+truncnorm frozen per-call : 8.697s  (434.9 us/call)
+ndtri inverse-CDF per-call: 0.049s  (  2.5 us/call)
+SPEEDUP on sampling       : 177x
+```
+And in the ACO cProfile, `scipy/_distn_infrastructure.py:892(freeze)` + `_construct_doc` + `doccer.docformat` account for ~4.8 s of a 7.9 s run.
+
+**Fix:** sample the truncated normal directly with the inverse CDF, allocating nothing:
+```python
+from scipy.special import ndtr, ndtri  # module-level import
+
+def _truncated_normal(mean, std, low, high, rng):
+    if std <= 0.0:
+        std = 1.0
+    a = ndtr((low - mean) / std)
+    b = ndtr((high - mean) / std)
+    u = rng.uniform(a, b)          # draw directly in the truncated CDF range
+    return float(mean + std * ndtri(u))
+```
+Behavior is statistically identical. This also removes the scipy `truncnorm` import from the hot path entirely.
+
+---
+
+### 2. Copy fixed data to workers **once**, not every generation *(your flagged item)*
+**Files:** `src/optimizers/continuous/aco.py:114-125`, `pso.py:140-153`, `ga.py:154-166`; `src/optimizers/core/base.py:68-77` (`setup_for_generations`)
+
+Today every generation calls `parallel(joblib.delayed(run_ants)(..., self.variables, self.wrapped_fcn, self.soln_deck.solution_archive))`. With `joblib_prefer="processes"`, joblib **pickles and ships every argument to every worker on every generation** — including the `variables` list, the wrapped goal function (which closes over `args`, i.e. your large fixed dataset), and the archive.
+
+**Evidence:** re-pickling a 16 MB fixed array for a 25-gen × 4-job run costs **0.57 s just in serialization** (5.7 ms per dispatch), before any transport or fitness work. For the large datasets you describe, this scales linearly and dominates.
+
+**Fix — send the immutable data once.** Two complementary approaches, both general:
+
+- **Persistent worker pool + initializer.** Replace the per-generation `joblib.delayed` fan-out with a `loky` reusable executor (or `concurrent.futures.ProcessPoolExecutor`) created once at `solve()` start, with an `initializer` that stashes the fixed payload (`variables`, `args`, goal fn) in a module global on each worker. Per generation you then dispatch only the *changing* data (the current archive, or just its indices). joblib's `loky` backend already keeps workers warm across `parallel()` calls when you reuse a single `Parallel(backend="loky")` instance — the missing piece is not re-sending the constant args.
+- **Memory-map large read-only arrays.** For big numpy payloads, hand workers a `np.memmap` (or rely on joblib's `max_nbytes` auto-memmap, which kicks in >1 MB) so the OS shares one physical copy across processes instead of pickling N copies. This is the lowest-risk way to stop replicating "a large section of memory."
+
+Design note: the current code is *structurally* ready for this — the fixed args (`variables`, `wrapped_fcn`) never change during a solve, and only `solution_archive` mutates per generation. Factor the parallel dispatch into a small reusable helper so ACO/PSO/GA share one implementation.
+
+---
+
+### 3. Bound the solution archive to `archive_size`
+**Files:** `src/optimizers/solution_deck.py:31-52` (`append`), `140-144` (`sort`); `src/optimizers/continuous/base.py:165-175` (`update_solution_deck`)
+
+`append` does `np.vstack`/`np.hstack` (full reallocation + copy) for every job output, and **the archive is never truncated back down to `archive_size`.** `deduplicate` only removes *near-duplicates*, so with a well-behaved objective the archive grows by ~`population_size` every generation forever.
+
+**Evidence:** an archive configured at **200 grew to 950** after a single early-stopped ACO run (would reach ~1450 over a full 25-gen run). Every `sort()` — called multiple times per generation via `deduplicate()` and `get_best()` — and every CDF / `searchsorted` / `other_values` slice then runs over this ever-growing array, so per-generation cost *increases* as the run proceeds.
+
+**Fix:**
+- After merging a generation, `sort()` once and slice `[:archive_size]`. Elitism is preserved (best solutions are kept) and memory/CPU become constant per generation.
+- Preallocate the archive as a fixed `(archive_size + max_batch, num_vars)` buffer and write into it, instead of `vstack`/`hstack` reallocating each append.
+
+---
+
+### 4. Reuse the global RNG instead of constructing one per call
+**Files:** `src/optimizers/continuous/variables.py:119` and `:135`
+
+`InputContinuousVariable.random_value` and `initial_random_value` call `np.random.default_rng()` **on every invocation**, constructing a fresh bit-generator each time (**~11.6 µs/call measured**) and *ignoring* the seeded global RNG in `core/random.py` — so results aren't reproducible even after `set_seed()`.
+
+**Fix:** use the shared `global_rng()` (already imported elsewhere in the file). Correctness bonus: reproducibility is restored. In worker processes, seed each worker's generator once from a base seed + worker id (via the initializer from #2).
+
+---
+
+### 5. Vectorize ACO `run_ants` across the population
+**File:** `src/optimizers/continuous/aco.py:35-70`
+
+`run_ants` loops in pure Python over ants × variables, calling `np.searchsorted` and `variable.random_value` scalar-by-scalar. `cdf(q_weight, len(archive))` is also recomputed on every worker call though it depends only on `q` and archive length.
+
+**Fix:** hoist `cdf` out (compute once per generation, pass in). Draw all base-solution indices for the batch at once (`np.searchsorted(cp_j, rng.uniform(size=n_ants))`). After #1, the per-variable sampling can be vectorized across ants because the truncated-normal draw becomes a pure array op (`ndtri` is vectorized). This turns the inner double loop into a handful of array operations.
+
+---
+
+### 6. Precompute `eta**beta` and `tau**alpha` in combinatorial ACO
+**Files:** `src/optimizers/combinatorial/aco.py:142-151` (`p_xy`), `aco_mst.py:107-116`
+
+`p_xy` evaluates `np.power(tau_xy[x,:], alpha) * np.power(eta_xy[x,:], beta)` on **every step of every ant of every generation.** `eta` (desirability, `1/distance`) *never changes*, yet `eta**beta` is recomputed billions of times; `tau` changes only once per generation.
+
+**Fix:** compute `eta_beta = eta**beta` **once** in `solve()` and pass it in; compute `tau_alpha = tau**alpha` **once per generation** before the parallel dispatch. This collapses the dominant cost from O(pop·steps·gens) to O(gens). Likely the single biggest combinatorial win.
+
+---
+
+### 7. Stop rebuilding the GA archive with `vstack` inside the results loop
+**File:** `src/optimizers/combinatorial/ga.py:96-103`
+
+For every individual returned every generation, the entire `genome` (archive_size × N) and `genome_value` are reallocated via `np.vstack`/`np.hstack` — O(pop²·N) copying per generation.
+
+**Fix:** collect the generation's `(order, length)` into Python lists, then do a **single** `np.stack`/`np.concatenate` before the sort/truncate. Or preallocate a fixed `archive_size + pop` buffer (same pattern as #3).
+
+---
+
+### 8. Replace FCM's BFGS with closed-form alternating updates
+**File:** `src/cluster/fcm.py:8-40`
+
+`minimize(optim_j_w_c, c.flatten(), method="BFGS")` uses finite-difference gradients, so the objective is called O(n·d) extra times per iteration, and each call rebuilds the full `N×C×D` broadcast tensor. Worse, `_j_w_c` computes the pairwise-difference tensor **twice** (once in `_get_weights` via `np.linalg.norm`, once inline as `np.sum((...)**2)`), taking a sqrt only to square it again; `_get_weights` also materializes an `N×C×C` tensor per call.
+
+**Fix:** fuzzy c-means has the standard closed-form alternating optimization — recompute memberships, then centers `c_j = Σ wᵐ x / Σ wᵐ` — which converges in a few cheap vectorized iterations with no finite-difference explosion. Compute the squared-distance matrix `N×C` **once** per iteration and reuse it for both memberships and objective. This is both faster and more numerically standard.
+
+---
+
+### 9. `@njit` the iVAT path-max double loop
+**File:** `src/cluster/mergevat.py:19-26`
+
+The iVAT reordering recursion (`for r in range(1,N): for c in range(r): ...`) is inherently O(N²) but runs as interpreted Python with scalar writes and a per-row `np.argmin` slice. The rest of the module already uses `@njit(cache=True)` well — this loop is the odd one out.
+
+**Fix:** move it into an `@njit(cache=True)` kernel (it's trivially numba-compatible: scalar indexing, `max`, `argmin`). Expect ~50–100× on this stage. **Related cleanups in the same file:** `progress_bar.update(1)` is called inside the inner O(N²) loop (`:65-66`) — update once per outer iteration; `key[vertices]`/`adj[u, vertices]` with `vertices=arange(N)` force full-length copies every Prim step (`:167-169`) — index directly; and `_get_dist` is computed twice in `vat_prim_mst_seq` (`:238` and `:240`). Also verify `heapq` inside the `@njit` `vat_prim_mst` (`:107`) actually compiles in nopython mode — if it silently falls back to object mode the `@njit` is doing nothing; an array-based Prim is faster for dense matrices anyway.
+
+---
+
+### 10. Vectorize `check_path_distance` and `delta_tau`
+**Files:** `src/optimizers/combinatorial/base.py:20-29`, `aco.py:92-99`, `aco_mst.py:77-84`
+
+`check_path_distance` is a scalar Python loop over the tour (called 2× per GA individual and per 2-opt result). Pheromone deposit `delta_tau` is a Python per-edge loop.
+
+**Fix:**
+- Distance: `distances[order[:-1], order[1:]].sum()` (+ the return-to-start edge). Prime `@njit` candidate.
+- Deposit: `np.add.at(delta_tau, (order[:-1], order[1:]), q/tour_length)` plus the closing edge — vectorizes the whole tour at once.
+- In `aco.py:187`, `np.random.choice(..., p=p)` is slow and lock-contended; replace with `np.searchsorted(np.cumsum(p), rng.random())` (as `aco_mst` already does).
+
+---
+
+### 11. Choose threads vs processes correctly — and document it
+**Files:** `src/optimizers/core/base.py:106` (`joblib_prefer="threads"` default), all `solve()` methods
+
+The default is `"threads"`. The inner worker bodies (`run_ants`, `run_ga`, ACO tour construction) are **largely pure Python**, so under the GIL threads give little speedup and add dispatch overhead. Threads only win when the fitness function is numpy-vectorized (releases the GIL) or you're on a free-threaded build (`sample.py` already probes `sys._is_gil_enabled()`).
+
+**Guidance to bake in:**
+- **CPU-bound pure-Python fitness →** `processes` (with #2 so fixed data isn't re-shipped).
+- **numpy-vectorized fitness / free-threaded 3.13t →** `threads` (no pickling, shared memory).
+- Document this tradeoff in the config docstring and pick a smarter default (e.g. `processes` when a large `args` payload is detected, else `threads`). Keep it a user-visible knob — it's workload-dependent.
+
+---
+
+### 12. Remove redundant `sort()` / `deduplicate()` passes per generation
+**Files:** `src/optimizers/continuous/base.py:165-175` (`update_solution_deck`), `solution_deck.py:97-144`
+
+`update_solution_deck` loops over each job output calling `append` then `deduplicate()` — and `deduplicate()` calls `sort()` internally, so with `n_jobs` outputs you re-sort the (growing, see #3) archive `n_jobs` times per generation, then `get_best()` sorts again.
+
+**Fix:** append **all** job outputs first, then `deduplicate()`/`sort()`/truncate **once** per generation.
+
+---
+
+### 13. `@njit` the local-search kernels
+**Files:** `src/optimizers/combinatorial/strategy.py` — `TwoOptTSP` (`:51-71`), `ThreeOptTSP` (`:122-305`), `NearestNeighborTSP` (`:348-369`), `ConvexHullTSP` (`:422-429`); `ga.py:161-181` (`_2opt_refine`, run 2× per GA individual)
+
+These are triple/double-nested Python loops with scalar matrix indexing and, in 3-opt, an `np.zeros(8)` allocated in the innermost O(n³) loop. `NearestNeighborTSP` uses a Python `set` membership scan.
+
+**Fix:** `@njit(cache=True)` the 2-opt/3-opt passes; for NN keep a boolean `visited` mask and use `np.argmin(np.where(mask, np.inf, distances[current]))`. These are the classic numba sweet spot (tight scalar loops over arrays).
+
+---
+
+### 14. Trim per-evaluation overhead in `bump_eval`
+**File:** `src/optimizers/continuous/base.py:47-58`
+
+Every wrapped fitness call runs `bump_eval`: a `time.time()` syscall plus several dict writes, on *every* objective evaluation. For millions of evals this is measurable pure overhead, and under `processes` the counter is per-worker anyway (so its "global" count is misleading).
+
+**Fix:** make the metadata bookkeeping opt-in (only when something actually consumes `eval_count`/`elapsed_time`), or update it once per generation rather than per evaluation.
+
+---
+
+### 15. Vectorize discrete `random_value`
+**File:** `src/optimizers/continuous/variables.py:33-47`
+
+`InputDiscreteVariable.random_value` does `np.concatenate((values, other_values))` then `np.unique(..., return_counts=True)` **per sample** to build a weighting — an O(M log M) sort on every draw.
+
+**Fix:** compute the weighting once per generation (it depends on the archive column, not the individual draw) and reuse it across all ants sampling that variable; or use `np.bincount` on integer-encoded categories.
+
+---
+
+## Suggested rollout
+
+1. **Quick wins first (a day):** #1, #4, #3, #12, #14 — all low-risk, mostly local edits, and together they should cut continuous-optimizer wall-clock several-fold. Run `pytest tests/` after each.
+2. **Architecture (the multiprocessing item):** #2 + #11 — factor a shared parallel-dispatch helper with a persistent pool/initializer and memmap for large read-only data. This is the change that pays off most on *your* large-dataset applications.
+3. **Vectorization/numba sweep:** #5, #6, #7, #10, #13 — biggest combinatorial gains.
+4. **Clustering:** #8, #9 — independent of the optimizer work; do whenever FCM/VAT matters.
+
+## Verification method
+
+Every change should be validated with (a) `pytest tests/` for correctness, and (b) a before/after timing on a fixed seed (`set_seed(42)`) using the existing test objectives (`optim_ackley`, `optim_rosenbrock`) at pop 50 / 25 gens — sized to run comfortably in 16 GB. The profiling harness used for this report samples ACO/PSO/GA under `n_jobs=1` (to isolate algorithm cost from dispatch) and separately under `processes` (to measure dispatch + serialization).
+
+---
+
+## Appendix — measured evidence
+
+**ACO single-worker timing (9 vars, pop 50, 25 gens):** ACO 6.30 s vs PSO 0.71 s vs GA 0.44 s — ACO is ~9–14× slower purely due to #1.
+
+**cProfile top of ACO run (7.96 s total):**
+- `run_ants` — 7.55 s cumulative
+- `variables.random_value` — 7.43 s → `__get_truncated_normal` 7.05 s
+- `scipy freeze/_construct_doc/docformat/splitlines` — **~4.8 s of pure docstring formatting**
+
+**Micro-benchmarks (Core i7-1185G7, inside `.venv`):**
+```
+truncnorm frozen per-call : 434.9 us/call
+ndtri inverse-CDF per-call:   2.5 us/call     -> 177x
+np.random.default_rng()   :  11.6 us/call     (constructed per sample today)
+re-pickle 16MB fixed data : 5.7 ms per generation-dispatch (100 dispatches = 0.57s)
+```
+
+**Archive growth:** configured `archive_size=200` → **950 rows** after one early-stopped run (unbounded growth, see #3).

--- a/PERF_PLAN.md
+++ b/PERF_PLAN.md
@@ -1,0 +1,45 @@
+# Performance Work — Stacked PR Plan
+
+This branch is the base of a **stacked PR chain**. Each branch merges into the one below
+it, so review and merge bottom-up. Findings and evidence live in
+[`PERFORMANCE_REPORT.md`](./PERFORMANCE_REPORT.md); the Cython/PYX evaluation lives in
+[`CYTHON_ANALYSIS.md`](./CYTHON_ANALYSIS.md).
+
+**Scope note:** the `src/cluster/` package (FCM, VAT/iVAT) is explicitly **out of scope** —
+it is being split into a separate package. Report items #8 (FCM) and #9 (iVAT) are deferred.
+
+## The stack
+
+| PR | Branch | Merges into | Report items | Risk |
+|----|--------|-------------|--------------|:----:|
+| 1 | `perf/1-plan-and-cython-analysis` | `main` | Plan + Cython analysis (docs only) | none |
+| 2 | `perf/2-continuous-quickwins` | PR1 | #1 truncnorm sampling, #4 RNG reuse, #14 `bump_eval` overhead | low |
+| 3 | `perf/3-solution-deck` | PR2 | #3 bound archive to `archive_size`, #12 sort/dedup once per gen | low |
+| 4 | `perf/4-aco-vectorize` | PR3 | #5 vectorize `run_ants` + hoist CDF, #15 discrete `random_value` | med |
+| 5 | `perf/5-parallel-arch` | PR4 | #2 send fixed data to workers once, #11 threads/processes guidance | med |
+| 6 | `perf/6-combinatorial` | PR5 | #6 precompute `eta**beta`/`tau**alpha`, #7 GA `vstack`, #10 vectorize distance/deposit, #13 njit local search | med |
+
+Each PR:
+- keeps changes **general and flexible** (no problem-specific assumptions);
+- preserves behavior (same optimizer semantics; seeded runs stay reproducible);
+- must keep `pytest tests/` green (excluding the out-of-scope `tests/test_cluster.py`);
+- includes a before/after timing on a fixed seed where it claims a speedup.
+
+## Baseline (Core i7-1185G7, inside `.venv`)
+
+- Full non-cluster suite: **18 passed in ~128 s** — the runtime is dominated by the
+  ACO/`truncnorm` hotspot that PR2 removes.
+- Headline hotspot: ~60% of ACO wall-clock is scipy building docstrings for a
+  per-sample `truncnorm` object (see report). Measured primitive speedup from the
+  PR2 fix: **177×**.
+
+## Ordering rationale
+
+1. **Quick wins first** (PR2) — biggest win for least risk; also makes the whole test
+   suite fast, which speeds up every subsequent PR's verification.
+2. **Solution deck** (PR3) — removes unbounded growth so later benchmarks are stable.
+3. **ACO vectorization** (PR4) — builds on the faster sampling primitive from PR2.
+4. **Parallel architecture** (PR5) — the "copy fixed data once" refactor; benefits from a
+   clean, bounded deck and vectorized workers underneath it.
+5. **Combinatorial** (PR6) — independent of the continuous stack; lands last so its
+   larger surface area doesn't block the high-value continuous fixes.


### PR DESCRIPTION
Base of the **stacked performance PR chain**. Docs only — no code changes.

## Contents
- **PERFORMANCE_REPORT.md** — profiled findings + ranked action plan (measured on Core i7-1185G7 inside `.venv`). Headline: ~60% of ACO wall-clock is scipy building docstrings for a per-sample `truncnorm` object; measured 177× speedup on the sampling primitive.
- **PERF_PLAN.md** — the 6-PR stacked plan. Each branch merges into the previous one; review bottom-up.
- **CYTHON_ANALYSIS.md** — evaluation of compiled `.pyx` (Cython) modules vs the already-present numba.

## The stack
| PR | Branch | Merges into |
|----|--------|-------------|
| 1 | `perf/1-plan-and-cython-analysis` | `main` |
| 2 | `perf/2-continuous-quickwins` | PR1 |
| 3 | `perf/3-solution-deck` | PR2 |
| 4 | `perf/4-aco-vectorize` | PR3 |
| 5 | `perf/5-parallel-arch` | PR4 |
| 6 | `perf/6-combinatorial` | PR5 |

## Scope
`src/cluster/` (FCM, VAT/iVAT) is **out of scope** — being split into a separate package.

## Cython analysis — bottom line
numba (already a dependency) covers most kernels with zero build/packaging cost. Cython is a *conditional yes*: reserved for optional `nogil` combinatorial local-search kernels under a shared-memory threading deployment, and only if numba's parallel `nogil` mode proves insufficient in benchmarking.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DoXi5fcpttwqEDjgS2WL6h