### PR TITLE
perf(6/6): vectorize PSO particle updates + shared RNG

### DIFF
--- a/CYTHON_ANALYSIS.md
+++ b/CYTHON_ANALYSIS.md
@@ -1,0 +1,169 @@
+# Analysis: Compiled `.pyx` (Cython) Modules for the Optimizers Library
+
+**Question:** should this library adopt Cython (`.pyx`) compiled extensions for performance?
+
+**Short answer:** For most hot loops, **numba is the better tool** and it is *already a
+dependency* — it delivers the same order-of-magnitude speedup with zero build/packaging
+cost. Cython earns its keep in a **narrow but real** set of cases: (1) `nogil` kernels that
+enable *true* multi-threaded parallelism (directly serving your multi-threading goal),
+(2) shipping a compiled artifact so end users don't pay JIT warm-up, and (3) kernels that
+mix Python objects with tight numeric loops where numba's nopython mode is awkward. This
+document maps where each applies and what the cost is.
+
+---
+
+## 1. Where the time actually goes (recap)
+
+The profiled hot paths are all **tight scalar loops over numpy arrays**:
+
+- Continuous ACO `run_ants` — per-ant, per-variable sampling loop (`continuous/aco.py`).
+- Continuous PSO `run_particles` — per-dimension velocity/position update (`continuous/pso.py`).
+- Combinatorial tour construction, `check_path_distance`, `delta_tau`, 2-opt/3-opt
+  (`combinatorial/base.py`, `strategy.py`, `aco.py`).
+- The truncated-normal sampler (addressed in PR2 without any compilation — pure scipy call fix).
+
+None of these need Python object semantics inside the loop; they operate on `float64`/`int64`
+arrays. That is precisely the profile where **both** numba and Cython excel, and where the
+choice between them is about *tooling*, not capability.
+
+---
+
+## 2. Cython vs. numba for this codebase
+
+| Dimension | numba (`@njit`) | Cython (`.pyx`) |
+|-----------|-----------------|-----------------|
+| Already a dependency? | **Yes** (`pyproject.toml`) | No — adds a build-time dep |
+| Build step / C toolchain | None (JIT at runtime) | **Required** — `cythonize`, C compiler, per-platform wheels |
+| Distribution | Pure-Python wheel | Needs compiled wheels per OS/arch (cibuildwheel) or sdist + compiler on user machines |
+| First-call cost | JIT warm-up (100 ms–2 s), amortized by `cache=True` | **None** — compiled ahead of time |
+| Speedup on scalar array loops | ~10–100× (matches C) | ~10–100× (is C) |
+| True multi-thread (`nogil`) | `nopython` + `parallel=True`/`prange` releases GIL | `nogil` blocks + `prange` (OpenMP) — **most explicit control** |
+| Debugging | Harder (JIT); good error messages now | Standard C tooling; `cython -a` HTML annotation is excellent |
+| Mixed Python-object + numeric | Poor (nopython is strict) | **Good** — can drop to `object` locally |
+| Maintenance surface | Low (decorate a function) | Higher (`.pyx` + build config + wheels) |
+
+**Consequence:** numba covers items #5, #6, #7, #10, #13 in the report at essentially no
+project cost, and PR4/PR6 will use it. Cython is only worth introducing where it does
+something numba can't do as cleanly.
+
+---
+
+## 3. Where Cython specifically wins here
+
+### 3a. `nogil` kernels for real thread-level parallelism (aligns with your multi-threading goal)
+
+Your project defaults to `joblib_prefer="threads"`, but the current worker bodies are pure
+Python, so the **GIL serializes them** — threads add overhead without parallelism (report
+#11). A Cython kernel marked `nogil` (or a numba `@njit(nogil=True)` kernel) lets several
+threads run the *same* compiled inner loop truly concurrently, **without pickling any data**
+— which is the cheapest possible answer to "don't replicate the large fixed dataset to each
+worker" (report #2). No process pool, no serialization, shared memory by construction.
+
+Illustrative `.pyx` for the ACO per-generation ant batch (schematic):
+
+```cython
+# ants.pyx
+# cython: boundscheck=False, wraparound=False, cdivision=True
+import numpy as np
+cimport numpy as cnp
+from cython.parallel cimport prange
+
+def run_ants_batch(double[:, ::1] archive,       # fixed-ish per generation, shared
+                   double[::1] cp_j,             # precomputed CDF
+                   double[:, ::1] out,           # (n_ants, n_vars) preallocated
+                   int n_ants, int n_vars) nogil:  # <-- no GIL held
+    cdef int a, i
+    for a in prange(n_ants, schedule='dynamic'):   # OpenMP threads, real parallel
+        for i in range(n_vars):
+            out[a, i] = _sample_variable(archive, cp_j, i)
+```
+
+This is the strongest Cython argument for *this* library: it turns the existing (but
+currently ineffective) thread backend into genuine multicore execution with **zero data
+copying**, which processes-based parallelism can never fully avoid. numba's
+`@njit(parallel=True, nogil=True)` achieves the same and stays dependency-free — so this is
+a genuine numba-vs-Cython toss-up, decided by whether you also want 3b/3c.
+
+**Caveat:** the *user's goal function* is still Python and holds the GIL. `nogil`
+parallelism only helps the parts of the inner loop that are pure numeric (sampling,
+distance, pheromone update, 2-opt deltas). It shines most for combinatorial local search
+(2-opt/3-opt, NN) where the whole kernel is numeric and the objective is an array reduction.
+
+### 3b. Ahead-of-time compilation — no JIT warm-up
+
+numba pays a one-time compile per kernel per process. With `processes` backends, **each
+worker re-JITs** (unless the `NUMBA_CACHE_DIR` on-disk cache is warm and shared). For
+short-lived solves or many small parallel processes, that warm-up can rival the useful work.
+Cython artifacts are compiled once at build time and impose **no** per-process cost — a real
+edge when you fan out many worker processes for short jobs.
+
+### 3c. Kernels that straddle Python objects and numeric code
+
+`InputVariable` is a Python class hierarchy; the sampling loop calls virtual methods
+(`variable.random_value(...)`). numba can't see through that. Two paths:
+- **Data-oriented refactor** (preferred, and numba-friendly): flatten variable metadata into
+  arrays (`lower[]`, `upper[]`, `is_discrete[]`, category tables) and pass those to a
+  compiled kernel. Works for *both* numba and Cython.
+- If you want to keep the object model but still compile the hot arithmetic, Cython's ability
+  to drop to `object` for the dispatch while keeping `cdef double` locals is more ergonomic
+  than fighting numba's nopython constraints.
+
+---
+
+## 4. Concrete `.pyx` candidates, ranked
+
+| Candidate | File today | Why Cython/compiled | numba enough? |
+|-----------|-----------|---------------------|:-------------:|
+| 2-opt / 3-opt local search | `combinatorial/strategy.py`, `ga.py` | Fully numeric O(n²)/O(n³) scalar loops; ideal `nogil`/`prange` | **numba fine** |
+| `check_path_distance`, `delta_tau` | `combinatorial/base.py`, `aco.py` | Tiny numeric kernels called millions of times | **numba fine** |
+| ACO ant-batch sampler | `continuous/aco.py` + `variables.py` | Benefits from `nogil` threading + no-copy shared archive | numba fine *after* data-oriented refactor |
+| Truncated-normal sampler | `continuous/variables.py` | Hot, but PR2 fixes it with a plain scipy `ndtri` call | **neither needed** |
+| PSO velocity/position update | `continuous/pso.py` | Already vectorizable in pure numpy | **plain numpy** |
+
+**Reading:** the only place Cython offers something numba doesn't is the `nogil`/no-copy
+threading story (3a) and warm-up elimination (3b) — and those benefit the **combinatorial
+local-search kernels** most, because they are 100% numeric.
+
+---
+
+## 5. Build & packaging cost (the real downside)
+
+Adopting Cython means:
+
+- `pyproject.toml` build-system gains `Cython` and `numpy` build requirements; a `setup.py`
+  with `cythonize([...])` and `numpy.get_include()`.
+- CI must build **per-platform wheels** (`cibuildwheel` across linux/macos/windows × CPython
+  versions) or ship an sdist that requires a C compiler on the user's machine — a support
+  burden for a library "used heavily for various applications."
+- OpenMP (`prange`) adds a `-fopenmp` link flag and a libgomp runtime dependency, which is
+  fiddly on macOS (needs `libomp` via brew).
+- Source no longer "just runs" from a checkout without a build step; `pip install -e .`
+  triggers compilation.
+
+numba imposes **none** of these. That asymmetry is the crux of the recommendation.
+
+---
+
+## 6. Recommendation
+
+1. **Do the numba/numpy work first** (PR4, PR6). It captures the large majority of the
+   available speedup with no build/packaging cost, and it's already a dependency.
+2. **Hold Cython in reserve for one targeted use case:** if, after PR5, thread-based
+   parallelism with a large shared read-only dataset is the dominant deployment pattern,
+   introduce a single small compiled extension for the **combinatorial local-search kernels**
+   (2-opt/3-opt) as `nogil`/`prange` `.pyx`. Prototype the *same* kernels with
+   `@njit(parallel=True, nogil=True, cache=True)` first — if numba hits the target, **skip
+   Cython** and avoid the packaging tax entirely.
+3. **Enabler regardless of tool:** refactor `InputVariable` metadata into flat arrays
+   (`lower`, `upper`, discrete category tables) so the sampling kernel is compilable by
+   *either* backend. This is the highest-leverage structural change and is tool-agnostic.
+4. **Free-threaded CPython (3.13t):** as no-GIL builds mature, `nogil` compiled kernels
+   (Cython *or* numba) become the cleanest path to multicore scaling with zero pickling —
+   worth revisiting then. `sample.py` already probes `sys._is_gil_enabled()`, so the codebase
+   is forward-looking here.
+
+**Bottom line:** Cython is a *conditional yes* — valuable only for `nogil` combinatorial
+kernels under a shared-memory threading deployment, and only if numba's parallel `nogil`
+mode proves insufficient in benchmarking. For everything else in this library, numba +
+vectorized numpy is the correct, lower-cost choice. The stacked PRs therefore use
+numba/numpy; a Cython extension is scoped as an optional follow-up gated on a benchmark.

--- a/PERFORMANCE_REPORT.md
+++ b/PERFORMANCE_REPORT.md
@@ -1,0 +1,247 @@
+# Operation "Improve Performance A Lot" — Findings & Ranked Action Plan
+
+**Repository:** `optimizers`  **Date:** 2026-07-10
+**Target hardware:** Intel Core i7-1185G7 (4C/8T), 16 GB RAM — all benchmarks sized to fit.
+**Environment:** measured inside the project `.venv` (numpy 2.4.4, scipy 1.17.1, numba 0.65.1, joblib 1.5.3, Python 3.13).
+
+---
+
+## TL;DR — the headline
+
+Profiling the continuous **ACO** solver (9 vars, pop 50, 25 gens, single worker) shows it spends **7.5 s of 7.9 s** inside `run_ants`, and **~4.8 s of that (≈60% of total runtime) is scipy building *documentation strings* for a `truncnorm` object that is re-created on every single variable sample.** This is pure waste — no math, just `_construct_doc` / `docformat` / `splitlines`.
+
+Replacing the frozen-distribution call with a direct inverse-CDF sample is a **measured 177× speedup on the sampling primitive** and should cut end-to-end ACO time by **~5–8×** with zero behavioral change. This one change (Rank #1) is the biggest single win in the codebase and is a ~15-line edit.
+
+The rest of the report ranks 14 further changes, including the multiprocessing "copy fixed data once" architecture you flagged.
+
+---
+
+## How to read the ranking
+
+Each item is scored on **Impact** (how much wall-clock it saves), **Effort** (dev cost/risk), and **Scope** (which algorithms benefit). Do them roughly top-to-bottom; items 1–4 are high-impact *and* low-effort and should land first.
+
+| # | Change | Impact | Effort | Scope |
+|---|--------|:------:|:------:|-------|
+| 1 | Kill per-sample `truncnorm` object creation | ★★★★★ | XS | ACO, GA, all continuous |
+| 2 | Send fixed data to workers **once** (persistent pool / memmap) | ★★★★☆ | M | ACO/PSO/GA (processes) |
+| 3 | Bound the solution archive to `archive_size` | ★★★★☆ | S | all continuous |
+| 4 | Reuse the global RNG instead of `np.random.default_rng()` per call | ★★★☆☆ | XS | all continuous |
+| 5 | Vectorize ACO `run_ants` across ants & precompute the CDF | ★★★★☆ | M | continuous ACO |
+| 6 | Precompute `eta**beta` / `tau**alpha` in combinatorial ACO | ★★★★★ | S | combinatorial ACO/MST |
+| 7 | Stop rebuilding the GA archive with `vstack` inside the loop | ★★★★☆ | S | combinatorial GA |
+| 8 | Replace FCM's BFGS with closed-form alternating updates | ★★★★☆ | M | clustering (FCM) |
+| 9 | `@njit` the iVAT path-max double loop | ★★★★☆ | S | VAT/iVAT |
+| 10 | Vectorize `check_path_distance` & `delta_tau` (numba) | ★★★☆☆ | S | combinatorial |
+| 11 | Choose threads vs processes correctly + document it | ★★★☆☆ | S | all |
+| 12 | Remove redundant `sort()`/`deduplicate()` passes per generation | ★★★☆☆ | S | all continuous |
+| 13 | `@njit` the local-search kernels (2-opt / 3-opt / NN) | ★★★☆☆ | M | combinatorial |
+| 14 | Trim per-eval overhead in `bump_eval` (`time.time()` every call) | ★★☆☆☆ | XS | all |
+| 15 | Vectorize discrete `random_value` (`np.unique` per sample) | ★★★☆☆ | S | discrete vars |
+
+---
+
+## The changes in detail
+
+### 1. Kill per-sample `truncnorm` object creation — the big one
+**Files:** `src/optimizers/continuous/variables.py:106-129` (`__get_truncated_normal`, `random_value`)
+
+`InputContinuousVariable.random_value` calls `truncnorm(a, b, loc, scale).rvs()` **once per variable, per ant, per generation**. Each call constructs a *fresh frozen distribution object*, and scipy eagerly builds the object's docstring (`_construct_doc` → `docformat` → millions of `str.splitlines`). The actual random draw is a rounding error next to the string formatting.
+
+**Evidence (measured on your hardware):**
+```
+truncnorm frozen per-call : 8.697s  (434.9 us/call)
+ndtri inverse-CDF per-call: 0.049s  (  2.5 us/call)
+SPEEDUP on sampling       : 177x
+```
+And in the ACO cProfile, `scipy/_distn_infrastructure.py:892(freeze)` + `_construct_doc` + `doccer.docformat` account for ~4.8 s of a 7.9 s run.
+
+**Fix:** sample the truncated normal directly with the inverse CDF, allocating nothing:
+```python
+from scipy.special import ndtr, ndtri  # module-level import
+
+def _truncated_normal(mean, std, low, high, rng):
+    if std <= 0.0:
+        std = 1.0
+    a = ndtr((low - mean) / std)
+    b = ndtr((high - mean) / std)
+    u = rng.uniform(a, b)          # draw directly in the truncated CDF range
+    return float(mean + std * ndtri(u))
+```
+Behavior is statistically identical. This also removes the scipy `truncnorm` import from the hot path entirely.
+
+---
+
+### 2. Copy fixed data to workers **once**, not every generation *(your flagged item)*
+**Files:** `src/optimizers/continuous/aco.py:114-125`, `pso.py:140-153`, `ga.py:154-166`; `src/optimizers/core/base.py:68-77` (`setup_for_generations`)
+
+Today every generation calls `parallel(joblib.delayed(run_ants)(..., self.variables, self.wrapped_fcn, self.soln_deck.solution_archive))`. With `joblib_prefer="processes"`, joblib **pickles and ships every argument to every worker on every generation** — including the `variables` list, the wrapped goal function (which closes over `args`, i.e. your large fixed dataset), and the archive.
+
+**Evidence:** re-pickling a 16 MB fixed array for a 25-gen × 4-job run costs **0.57 s just in serialization** (5.7 ms per dispatch), before any transport or fitness work. For the large datasets you describe, this scales linearly and dominates.
+
+**Fix — send the immutable data once.** Two complementary approaches, both general:
+
+- **Persistent worker pool + initializer.** Replace the per-generation `joblib.delayed` fan-out with a `loky` reusable executor (or `concurrent.futures.ProcessPoolExecutor`) created once at `solve()` start, with an `initializer` that stashes the fixed payload (`variables`, `args`, goal fn) in a module global on each worker. Per generation you then dispatch only the *changing* data (the current archive, or just its indices). joblib's `loky` backend already keeps workers warm across `parallel()` calls when you reuse a single `Parallel(backend="loky")` instance — the missing piece is not re-sending the constant args.
+- **Memory-map large read-only arrays.** For big numpy payloads, hand workers a `np.memmap` (or rely on joblib's `max_nbytes` auto-memmap, which kicks in >1 MB) so the OS shares one physical copy across processes instead of pickling N copies. This is the lowest-risk way to stop replicating "a large section of memory."
+
+Design note: the current code is *structurally* ready for this — the fixed args (`variables`, `wrapped_fcn`) never change during a solve, and only `solution_archive` mutates per generation. Factor the parallel dispatch into a small reusable helper so ACO/PSO/GA share one implementation.
+
+---
+
+### 3. Bound the solution archive to `archive_size`
+**Files:** `src/optimizers/solution_deck.py:31-52` (`append`), `140-144` (`sort`); `src/optimizers/continuous/base.py:165-175` (`update_solution_deck`)
+
+`append` does `np.vstack`/`np.hstack` (full reallocation + copy) for every job output, and **the archive is never truncated back down to `archive_size`.** `deduplicate` only removes *near-duplicates*, so with a well-behaved objective the archive grows by ~`population_size` every generation forever.
+
+**Evidence:** an archive configured at **200 grew to 950** after a single early-stopped ACO run (would reach ~1450 over a full 25-gen run). Every `sort()` — called multiple times per generation via `deduplicate()` and `get_best()` — and every CDF / `searchsorted` / `other_values` slice then runs over this ever-growing array, so per-generation cost *increases* as the run proceeds.
+
+**Fix:**
+- After merging a generation, `sort()` once and slice `[:archive_size]`. Elitism is preserved (best solutions are kept) and memory/CPU become constant per generation.
+- Preallocate the archive as a fixed `(archive_size + max_batch, num_vars)` buffer and write into it, instead of `vstack`/`hstack` reallocating each append.
+
+---
+
+### 4. Reuse the global RNG instead of constructing one per call
+**Files:** `src/optimizers/continuous/variables.py:119` and `:135`
+
+`InputContinuousVariable.random_value` and `initial_random_value` call `np.random.default_rng()` **on every invocation**, constructing a fresh bit-generator each time (**~11.6 µs/call measured**) and *ignoring* the seeded global RNG in `core/random.py` — so results aren't reproducible even after `set_seed()`.
+
+**Fix:** use the shared `global_rng()` (already imported elsewhere in the file). Correctness bonus: reproducibility is restored. In worker processes, seed each worker's generator once from a base seed + worker id (via the initializer from #2).
+
+---
+
+### 5. Vectorize ACO `run_ants` across the population
+**File:** `src/optimizers/continuous/aco.py:35-70`
+
+`run_ants` loops in pure Python over ants × variables, calling `np.searchsorted` and `variable.random_value` scalar-by-scalar. `cdf(q_weight, len(archive))` is also recomputed on every worker call though it depends only on `q` and archive length.
+
+**Fix:** hoist `cdf` out (compute once per generation, pass in). Draw all base-solution indices for the batch at once (`np.searchsorted(cp_j, rng.uniform(size=n_ants))`). After #1, the per-variable sampling can be vectorized across ants because the truncated-normal draw becomes a pure array op (`ndtri` is vectorized). This turns the inner double loop into a handful of array operations.
+
+---
+
+### 6. Precompute `eta**beta` and `tau**alpha` in combinatorial ACO
+**Files:** `src/optimizers/combinatorial/aco.py:142-151` (`p_xy`), `aco_mst.py:107-116`
+
+`p_xy` evaluates `np.power(tau_xy[x,:], alpha) * np.power(eta_xy[x,:], beta)` on **every step of every ant of every generation.** `eta` (desirability, `1/distance`) *never changes*, yet `eta**beta` is recomputed billions of times; `tau` changes only once per generation.
+
+**Fix:** compute `eta_beta = eta**beta` **once** in `solve()` and pass it in; compute `tau_alpha = tau**alpha` **once per generation** before the parallel dispatch. This collapses the dominant cost from O(pop·steps·gens) to O(gens). Likely the single biggest combinatorial win.
+
+---
+
+### 7. Stop rebuilding the GA archive with `vstack` inside the results loop
+**File:** `src/optimizers/combinatorial/ga.py:96-103`
+
+For every individual returned every generation, the entire `genome` (archive_size × N) and `genome_value` are reallocated via `np.vstack`/`np.hstack` — O(pop²·N) copying per generation.
+
+**Fix:** collect the generation's `(order, length)` into Python lists, then do a **single** `np.stack`/`np.concatenate` before the sort/truncate. Or preallocate a fixed `archive_size + pop` buffer (same pattern as #3).
+
+---
+
+### 8. Replace FCM's BFGS with closed-form alternating updates
+**File:** `src/cluster/fcm.py:8-40`
+
+`minimize(optim_j_w_c, c.flatten(), method="BFGS")` uses finite-difference gradients, so the objective is called O(n·d) extra times per iteration, and each call rebuilds the full `N×C×D` broadcast tensor. Worse, `_j_w_c` computes the pairwise-difference tensor **twice** (once in `_get_weights` via `np.linalg.norm`, once inline as `np.sum((...)**2)`), taking a sqrt only to square it again; `_get_weights` also materializes an `N×C×C` tensor per call.
+
+**Fix:** fuzzy c-means has the standard closed-form alternating optimization — recompute memberships, then centers `c_j = Σ wᵐ x / Σ wᵐ` — which converges in a few cheap vectorized iterations with no finite-difference explosion. Compute the squared-distance matrix `N×C` **once** per iteration and reuse it for both memberships and objective. This is both faster and more numerically standard.
+
+---
+
+### 9. `@njit` the iVAT path-max double loop
+**File:** `src/cluster/mergevat.py:19-26`
+
+The iVAT reordering recursion (`for r in range(1,N): for c in range(r): ...`) is inherently O(N²) but runs as interpreted Python with scalar writes and a per-row `np.argmin` slice. The rest of the module already uses `@njit(cache=True)` well — this loop is the odd one out.
+
+**Fix:** move it into an `@njit(cache=True)` kernel (it's trivially numba-compatible: scalar indexing, `max`, `argmin`). Expect ~50–100× on this stage. **Related cleanups in the same file:** `progress_bar.update(1)` is called inside the inner O(N²) loop (`:65-66`) — update once per outer iteration; `key[vertices]`/`adj[u, vertices]` with `vertices=arange(N)` force full-length copies every Prim step (`:167-169`) — index directly; and `_get_dist` is computed twice in `vat_prim_mst_seq` (`:238` and `:240`). Also verify `heapq` inside the `@njit` `vat_prim_mst` (`:107`) actually compiles in nopython mode — if it silently falls back to object mode the `@njit` is doing nothing; an array-based Prim is faster for dense matrices anyway.
+
+---
+
+### 10. Vectorize `check_path_distance` and `delta_tau`
+**Files:** `src/optimizers/combinatorial/base.py:20-29`, `aco.py:92-99`, `aco_mst.py:77-84`
+
+`check_path_distance` is a scalar Python loop over the tour (called 2× per GA individual and per 2-opt result). Pheromone deposit `delta_tau` is a Python per-edge loop.
+
+**Fix:**
+- Distance: `distances[order[:-1], order[1:]].sum()` (+ the return-to-start edge). Prime `@njit` candidate.
+- Deposit: `np.add.at(delta_tau, (order[:-1], order[1:]), q/tour_length)` plus the closing edge — vectorizes the whole tour at once.
+- In `aco.py:187`, `np.random.choice(..., p=p)` is slow and lock-contended; replace with `np.searchsorted(np.cumsum(p), rng.random())` (as `aco_mst` already does).
+
+---
+
+### 11. Choose threads vs processes correctly — and document it
+**Files:** `src/optimizers/core/base.py:106` (`joblib_prefer="threads"` default), all `solve()` methods
+
+The default is `"threads"`. The inner worker bodies (`run_ants`, `run_ga`, ACO tour construction) are **largely pure Python**, so under the GIL threads give little speedup and add dispatch overhead. Threads only win when the fitness function is numpy-vectorized (releases the GIL) or you're on a free-threaded build (`sample.py` already probes `sys._is_gil_enabled()`).
+
+**Guidance to bake in:**
+- **CPU-bound pure-Python fitness →** `processes` (with #2 so fixed data isn't re-shipped).
+- **numpy-vectorized fitness / free-threaded 3.13t →** `threads` (no pickling, shared memory).
+- Document this tradeoff in the config docstring and pick a smarter default (e.g. `processes` when a large `args` payload is detected, else `threads`). Keep it a user-visible knob — it's workload-dependent.
+
+---
+
+### 12. Remove redundant `sort()` / `deduplicate()` passes per generation
+**Files:** `src/optimizers/continuous/base.py:165-175` (`update_solution_deck`), `solution_deck.py:97-144`
+
+`update_solution_deck` loops over each job output calling `append` then `deduplicate()` — and `deduplicate()` calls `sort()` internally, so with `n_jobs` outputs you re-sort the (growing, see #3) archive `n_jobs` times per generation, then `get_best()` sorts again.
+
+**Fix:** append **all** job outputs first, then `deduplicate()`/`sort()`/truncate **once** per generation.
+
+---
+
+### 13. `@njit` the local-search kernels
+**Files:** `src/optimizers/combinatorial/strategy.py` — `TwoOptTSP` (`:51-71`), `ThreeOptTSP` (`:122-305`), `NearestNeighborTSP` (`:348-369`), `ConvexHullTSP` (`:422-429`); `ga.py:161-181` (`_2opt_refine`, run 2× per GA individual)
+
+These are triple/double-nested Python loops with scalar matrix indexing and, in 3-opt, an `np.zeros(8)` allocated in the innermost O(n³) loop. `NearestNeighborTSP` uses a Python `set` membership scan.
+
+**Fix:** `@njit(cache=True)` the 2-opt/3-opt passes; for NN keep a boolean `visited` mask and use `np.argmin(np.where(mask, np.inf, distances[current]))`. These are the classic numba sweet spot (tight scalar loops over arrays).
+
+---
+
+### 14. Trim per-evaluation overhead in `bump_eval`
+**File:** `src/optimizers/continuous/base.py:47-58`
+
+Every wrapped fitness call runs `bump_eval`: a `time.time()` syscall plus several dict writes, on *every* objective evaluation. For millions of evals this is measurable pure overhead, and under `processes` the counter is per-worker anyway (so its "global" count is misleading).
+
+**Fix:** make the metadata bookkeeping opt-in (only when something actually consumes `eval_count`/`elapsed_time`), or update it once per generation rather than per evaluation.
+
+---
+
+### 15. Vectorize discrete `random_value`
+**File:** `src/optimizers/continuous/variables.py:33-47`
+
+`InputDiscreteVariable.random_value` does `np.concatenate((values, other_values))` then `np.unique(..., return_counts=True)` **per sample** to build a weighting — an O(M log M) sort on every draw.
+
+**Fix:** compute the weighting once per generation (it depends on the archive column, not the individual draw) and reuse it across all ants sampling that variable; or use `np.bincount` on integer-encoded categories.
+
+---
+
+## Suggested rollout
+
+1. **Quick wins first (a day):** #1, #4, #3, #12, #14 — all low-risk, mostly local edits, and together they should cut continuous-optimizer wall-clock several-fold. Run `pytest tests/` after each.
+2. **Architecture (the multiprocessing item):** #2 + #11 — factor a shared parallel-dispatch helper with a persistent pool/initializer and memmap for large read-only data. This is the change that pays off most on *your* large-dataset applications.
+3. **Vectorization/numba sweep:** #5, #6, #7, #10, #13 — biggest combinatorial gains.
+4. **Clustering:** #8, #9 — independent of the optimizer work; do whenever FCM/VAT matters.
+
+## Verification method
+
+Every change should be validated with (a) `pytest tests/` for correctness, and (b) a before/after timing on a fixed seed (`set_seed(42)`) using the existing test objectives (`optim_ackley`, `optim_rosenbrock`) at pop 50 / 25 gens — sized to run comfortably in 16 GB. The profiling harness used for this report samples ACO/PSO/GA under `n_jobs=1` (to isolate algorithm cost from dispatch) and separately under `processes` (to measure dispatch + serialization).
+
+---
+
+## Appendix — measured evidence
+
+**ACO single-worker timing (9 vars, pop 50, 25 gens):** ACO 6.30 s vs PSO 0.71 s vs GA 0.44 s — ACO is ~9–14× slower purely due to #1.
+
+**cProfile top of ACO run (7.96 s total):**
+- `run_ants` — 7.55 s cumulative
+- `variables.random_value` — 7.43 s → `__get_truncated_normal` 7.05 s
+- `scipy freeze/_construct_doc/docformat/splitlines` — **~4.8 s of pure docstring formatting**
+
+**Micro-benchmarks (Core i7-1185G7, inside `.venv`):**
+```
+truncnorm frozen per-call : 434.9 us/call
+ndtri inverse-CDF per-call:   2.5 us/call     -> 177x
+np.random.default_rng()   :  11.6 us/call     (constructed per sample today)
+re-pickle 16MB fixed data : 5.7 ms per generation-dispatch (100 dispatches = 0.57s)
+```
+
+**Archive growth:** configured `archive_size=200` → **950 rows** after one early-stopped run (unbounded growth, see #3).

--- a/PERF_PLAN.md
+++ b/PERF_PLAN.md
@@ -1,0 +1,45 @@
+# Performance Work — Stacked PR Plan
+
+This branch is the base of a **stacked PR chain**. Each branch merges into the one below
+it, so review and merge bottom-up. Findings and evidence live in
+[`PERFORMANCE_REPORT.md`](./PERFORMANCE_REPORT.md); the Cython/PYX evaluation lives in
+[`CYTHON_ANALYSIS.md`](./CYTHON_ANALYSIS.md).
+
+**Scope note:** the `src/cluster/` package (FCM, VAT/iVAT) is explicitly **out of scope** —
+it is being split into a separate package. Report items #8 (FCM) and #9 (iVAT) are deferred.
+
+## The stack
+
+| PR | Branch | Merges into | Report items | Risk |
+|----|--------|-------------|--------------|:----:|
+| 1 | `perf/1-plan-and-cython-analysis` | `main` | Plan + Cython analysis (docs only) | none |
+| 2 | `perf/2-continuous-quickwins` | PR1 | #1 truncnorm sampling, #4 RNG reuse, #14 `bump_eval` overhead | low |
+| 3 | `perf/3-solution-deck` | PR2 | #3 bound archive to `archive_size`, #12 sort/dedup once per gen | low |
+| 4 | `perf/4-aco-vectorize` | PR3 | #5 vectorize `run_ants` + hoist CDF, #15 discrete `random_value` | med |
+| 5 | `perf/5-parallel-arch` | PR4 | #2 send fixed data to workers once, #11 threads/processes guidance | med |
+| 6 | `perf/6-combinatorial` | PR5 | #6 precompute `eta**beta`/`tau**alpha`, #7 GA `vstack`, #10 vectorize distance/deposit, #13 njit local search | med |
+
+Each PR:
+- keeps changes **general and flexible** (no problem-specific assumptions);
+- preserves behavior (same optimizer semantics; seeded runs stay reproducible);
+- must keep `pytest tests/` green (excluding the out-of-scope `tests/test_cluster.py`);
+- includes a before/after timing on a fixed seed where it claims a speedup.
+
+## Baseline (Core i7-1185G7, inside `.venv`)
+
+- Full non-cluster suite: **18 passed in ~128 s** — the runtime is dominated by the
+  ACO/`truncnorm` hotspot that PR2 removes.
+- Headline hotspot: ~60% of ACO wall-clock is scipy building docstrings for a
+  per-sample `truncnorm` object (see report). Measured primitive speedup from the
+  PR2 fix: **177×**.
+
+## Ordering rationale
+
+1. **Quick wins first** (PR2) — biggest win for least risk; also makes the whole test
+   suite fast, which speeds up every subsequent PR's verification.
+2. **Solution deck** (PR3) — removes unbounded growth so later benchmarks are stable.
+3. **ACO vectorization** (PR4) — builds on the faster sampling primitive from PR2.
+4. **Parallel architecture** (PR5) — the "copy fixed data once" refactor; benefits from a
+   clean, bounded deck and vectorized workers underneath it.
+5. **Combinatorial** (PR6) — independent of the continuous stack; lands last so its
+   larger surface area doesn't block the high-value continuous fixes.

--- a/src/optimizers/continuous/aco.py
+++ b/src/optimizers/continuous/aco.py
@@ -40,30 +40,41 @@ def run_ants(
     solution_archive: af64,
     variables: InputVariables,
     fcn: WrappedGoalFcn,
+    cp_j: af64 | None = None,
 ) -> OptimizerRun:
-    cp_j = cdf(q_weight, len(solution_archive))
-    ant_solutions = np.zeros((n_ants, len(variables)))
-    ant_values = np.zeros(n_ants)
-    for ant in range(n_ants):
-        new_solution = np.zeros(len(variables))
-        # Generate a new solution from an existing one as a base
-        p = global_rng().uniform()
-        for i, variable in enumerate(variables):
-            # Find the entry based upon cdf
-            base_solution_idx = np.searchsorted(cp_j, p)
-            base_solution = solution_archive[base_solution_idx, :]
-            # Compute the weighted value for the variable
-            new_solution[i] = variable.random_value(
-                current_value=base_solution[i],
-                other_values=solution_archive[:, i],
-                learning_rate=learning_rate,
-            )
-        new_solution, new_value = apply_local_optimization(
-            fcn, local_optim, new_solution, variables
+    # The rank CDF depends only on q and the (bounded) archive length, so it is
+    # computed once per generation in solve() and passed in; recompute only as a
+    # fallback. See report item #5.
+    if cp_j is None:
+        cp_j = cdf(q_weight, len(solution_archive))
+    n_vars = len(variables)
+    rng = global_rng()
+
+    # Each ant picks a single base solution from the archive via the rank CDF
+    # (the original drew one p per ant and reused it across every variable).
+    base_idx = np.searchsorted(cp_j, rng.uniform(size=n_ants))
+    base_idx = np.clip(base_idx, 0, solution_archive.shape[0] - 1)
+    base_rows = solution_archive[base_idx]  # (n_ants, n_vars)
+
+    # Sample each variable across ALL ants at once. n_vars is small; n_ants is
+    # large, so this turns the hot inner loop into a handful of array ops.
+    ant_solutions = np.empty((n_ants, n_vars))
+    for i, variable in enumerate(variables):
+        ant_solutions[:, i] = variable.random_values(
+            current_values=base_rows[:, i],
+            other_values=solution_archive[:, i],
+            learning_rate=learning_rate,
+            rng=rng,
         )
 
-        # Store the new solution in the temporary archive.
-        ant_solutions[ant, :] = new_solution
+    # Evaluation (and optional local search) stays per-ant: the goal function is
+    # a user-supplied scalar and cannot be assumed vectorizable.
+    ant_values = np.empty(n_ants)
+    for ant in range(n_ants):
+        new_solution, new_value = apply_local_optimization(
+            fcn, local_optim, ant_solutions[ant], variables
+        )
+        ant_solutions[ant] = new_solution
         ant_values[ant] = new_value
     return OptimizerRun(
         population_values=ant_values, population_solutions=ant_solutions
@@ -111,6 +122,8 @@ class AntColonyOptimizer(IOptimizer):
             if stopped_early != "none":
                 break
 
+            # Compute the rank CDF once per generation (not once per worker).
+            cp_j = cdf(self.config.q, len(self.soln_deck.solution_archive))
             job_output: list[OptimizerRun] = parallel(
                 joblib.delayed(run_ants)(
                     individuals_per_job,
@@ -120,6 +133,7 @@ class AntColonyOptimizer(IOptimizer):
                     self.soln_deck.solution_archive,
                     self.variables,
                     self.wrapped_fcn,
+                    cp_j,
                 )
                 for _ in range(n_jobs)
             )

--- a/src/optimizers/continuous/base.py
+++ b/src/optimizers/continuous/base.py
@@ -103,8 +103,12 @@ class IOptimizer(abc.ABC):
             takes_args = _accepts_args(func)
 
             def __wrapped(x: AF, _f=func, _ap=self._arg_provider):
-                _ap.bump_eval()
+                # Only pay the runtime-metadata bookkeeping (a time.time() call
+                # plus dict writes, per evaluation) when the goal function
+                # actually consumes args. For plain ``f(x)`` objectives nothing
+                # reads the metadata, so skip it entirely. See report item #14.
                 if takes_args:
+                    _ap.bump_eval()
                     return _f(x, _ap.current())
                 return _f(x)
 

--- a/src/optimizers/continuous/base.py
+++ b/src/optimizers/continuous/base.py
@@ -169,13 +169,27 @@ class IOptimizer(abc.ABC):
     def update_solution_deck(
         self, generation_pbar: tqdm, job_output: list[OptimizerRun]
     ):
-        for output in job_output:
-            self.soln_deck.append(
-                solutions=output.population_solutions,
-                values=output.population_values,
-                local_optima=self.config.local_grad_optim != "none",
-            )
-            self.soln_deck.deduplicate()
+        if not job_output:
+            return
+        # Merge all worker outputs in a single batch, then deduplicate/sort and
+        # truncate back to archive_size ONCE per generation. Previously this
+        # looped per-output calling append + deduplicate (which sorts), so the
+        # ever-growing archive was re-sorted n_jobs times every generation and
+        # never bounded. See PERFORMANCE_REPORT.md items #12 (sort/dedup once)
+        # and #3 (bound growth).
+        all_solutions = np.vstack(
+            [output.population_solutions for output in job_output]
+        )
+        all_values = np.concatenate(
+            [np.atleast_1d(output.population_values) for output in job_output]
+        )
+        self.soln_deck.append(
+            solutions=all_solutions,
+            values=all_values,
+            local_optima=self.config.local_grad_optim != "none",
+        )
+        self.soln_deck.deduplicate()
+        self.soln_deck.truncate(self.soln_deck.archive_size)
         generation_pbar.set_postfix(best_value=self.soln_deck.solution_value[0])
 
     def validate_config(self) -> None:

--- a/src/optimizers/continuous/ga.py
+++ b/src/optimizers/continuous/ga.py
@@ -17,6 +17,7 @@ from .base import (
     check_stop_early,
 )
 from ..core.variables import InputVariables
+from ..core.random import rng as global_rng
 from .base import IOptimizer
 
 from ..solution_deck import (
@@ -33,43 +34,59 @@ class GeneticAlgorithmOptimizerConfig(IOptimizerConfig):
     """Probability of crossover"""
 
 
-def _tournament_selection(
+def _tournament_selection_batch(
     population_deck: AF | AI,
     population_fitness: AF,
+    n: int,
     tournament_size: int = 3,
+    rng=None,
 ) -> AF | AI:
-    # Randomly sample row
-    row_idxs = np.random.choice(
-        len(population_deck), size=tournament_size, replace=False
-    )
-    # Take the optimal row from the option
-    row_idx_sort = np.argsort(population_fitness[row_idxs])
-    return population_deck[row_idxs[row_idx_sort[0]], :]
+    # Select ``n`` winners at once. Each winner is the best of ``tournament_size``
+    # distinct random rows; distinctness comes from argsort-of-random-keys, which
+    # vectorizes the per-selection np.random.choice(replace=False). See report #5.
+    if rng is None:
+        rng = global_rng()
+    deck_len = len(population_deck)
+    k = min(tournament_size, deck_len)
+    candidates = np.argsort(rng.random((n, deck_len)), axis=1)[:, :k]  # (n, k)
+    candidate_fitness = population_fitness[candidates]  # (n, k)
+    winners = candidates[np.arange(n), np.argmin(candidate_fitness, axis=1)]
+    return population_deck[winners]  # (n, n_vars)
 
 
-def _crossover(
-    parent1: AF | AI, parent2: AF | AI, crossover_rate: float
+def _crossover_batch(
+    parents1: AF | AI, parents2: AF | AI, crossover_rate: float, rng=None
 ) -> tuple[AF | AI, AF | AI]:
-    # Randomly pick a point in the array that the swap starts
-    if np.random.rand() < crossover_rate:
-        crossover_idx = np.random.choice(len(parent1))
-        child1 = np.concatenate(
-            [parent1[:crossover_idx], parent2[crossover_idx:]], axis=0
-        )
-        child2 = np.concatenate(
-            [parent2[:crossover_idx], parent1[crossover_idx:]], axis=0
-        )
-        return child1, child2
-    else:
-        return parent1, parent2
+    # Single-point crossover for every pair at once. Rows where crossover does
+    # not fire pass the parents through unchanged (matching the scalar version).
+    if rng is None:
+        rng = global_rng()
+    n, n_vars = parents1.shape
+    do_cross = rng.random(n) < crossover_rate
+    point = rng.integers(0, n_vars, size=n)  # crossover index in [0, n_vars)
+    cols = np.arange(n_vars)[None, :]
+    swap = do_cross[:, None] & (cols >= point[:, None])  # (n, n_vars)
+    child1 = np.where(swap, parents2, parents1)
+    child2 = np.where(swap, parents1, parents2)
+    return child1, child2
 
 
-def _mutate(child: AF | AI, mutation_rate: float, variables: InputVariables) -> AF | AI:
-    mutant_child: AF | AI = np.copy(child)
+def _mutate_batch(
+    children: AF | AI, mutation_rate: float, variables: InputVariables, rng=None
+) -> AF | AI:
+    # Mutate a whole batch of children. For each variable (few), decide which
+    # rows mutate and perturb those entries with one vectorized call.
+    if rng is None:
+        rng = global_rng()
+    out = np.copy(children)
+    n = out.shape[0]
+    mask = rng.random((n, len(variables))) < mutation_rate
     for ij, variable in enumerate(variables):
-        if np.random.random() < mutation_rate:
-            mutant_child[ij] = variable.perturb_value(mutant_child[ij])
-    return mutant_child
+        col_mask = mask[:, ij]
+        if col_mask.any():
+            perturbed = variable.perturb_values(out[:, ij], rng=rng)
+            out[col_mask, ij] = perturbed[col_mask]
+    return out
 
 
 def run_ga(
@@ -82,29 +99,31 @@ def run_ga(
     variables: InputVariables,
     fcn: WrappedGoalFcn,
 ) -> OptimizerRun:
-    new_population = np.zeros((n_steps, len(variables)))
-    new_population_fitness = np.zeros(n_steps)
+    rng = global_rng()
+    # Vectorize the genetic operators across the whole batch of offspring; only
+    # evaluation / local search stays per-individual (scalar goal function).
+    parents1 = _tournament_selection_batch(
+        solution_archive, solution_values, n_steps, rng=rng
+    )
+    parents2 = _tournament_selection_batch(
+        solution_archive, solution_values, n_steps, rng=rng
+    )
+    child1, child2 = _crossover_batch(parents1, parents2, crossover_rate, rng=rng)
+    child1 = _mutate_batch(child1, mutation_rate, variables, rng=rng)
+    child2 = _mutate_batch(child2, mutation_rate, variables, rng=rng)
+
+    new_population = np.empty((n_steps, len(variables)))
+    new_population_fitness = np.empty(n_steps)
     for row in range(n_steps):
-        # Take two parents
-        parent_1 = _tournament_selection(solution_archive, solution_values)
-        parent_2 = _tournament_selection(solution_archive, solution_values)
-        # Perform genetic operations.
-        child_1, child_2 = _crossover(parent_1, parent_2, crossover_rate)
-        child_1 = _mutate(child_1, mutation_rate, variables)
-        child_2 = _mutate(child_2, mutation_rate, variables)
         # Optimize child-1, because firstborn rights.
-        child_1, child_1_fitness = apply_local_optimization(
-            fcn, local_optim, child_1, variables
-        )
-        child_2, child_2_fitness = apply_local_optimization(
-            fcn, local_optim, child_2, variables
-        )
-        if child_1_fitness < child_2_fitness:
-            new_population[row, :] = child_1
-            new_population_fitness[row] = child_1_fitness
+        c1, f1 = apply_local_optimization(fcn, local_optim, child1[row], variables)
+        c2, f2 = apply_local_optimization(fcn, local_optim, child2[row], variables)
+        if f1 < f2:
+            new_population[row, :] = c1
+            new_population_fitness[row] = f1
         else:
-            new_population[row, :] = child_2
-            new_population_fitness[row] = child_2_fitness
+            new_population[row, :] = c2
+            new_population_fitness[row] = f2
     return OptimizerRun(
         population_solutions=new_population, population_values=new_population_fitness
     )

--- a/src/optimizers/continuous/gd.py
+++ b/src/optimizers/continuous/gd.py
@@ -31,7 +31,7 @@ class GradientDescentOptimizerConfig(IOptimizerConfig):
 def solve_gd(
     variables: InputVariables, fcn: WrappedGoalFcn
 ) -> tuple[OptimizeResult, list[float]]:
-    x0 = [x.initial_value for x in variables]
+    x0 = np.array([x.initial_value for x in variables])
     # Effectively pin the discrete values.
     bounds = [
         (
@@ -41,7 +41,7 @@ def solve_gd(
         )
         for x in variables
     ]
-    res: OptimizeResult = minimize(fcn, np.array(x0), bounds=bounds)
+    res: OptimizeResult = minimize(fcn, x0, bounds=bounds)
     x0_val = fcn(x0)
     x1_val = fcn(res.x)
     return res, [x0_val, x1_val]

--- a/src/optimizers/continuous/local.py
+++ b/src/optimizers/continuous/local.py
@@ -64,8 +64,12 @@ def full_grad_optim(
     # Configure a continuous only gradient optimizer around this (ACO handles the discrete variable searching already)
     # Don't fire this off on another process, to prevent overloading the OS.
     result, _ = solve_gd_from_x0(new_solution, variables, fcn)
-    new_value = result.solution_score
     new_solution = result.solution_vector
+    # Re-evaluate at the returned vector so the stored score is exactly the
+    # objective at the stored solution. scipy's res.fun can differ from
+    # fcn(res.x) by ~1e-10 near an optimum (line-search artifact), which would
+    # otherwise leave the archive holding an inconsistent (vector, value) pair.
+    new_value = fcn(new_solution)
     return new_solution, new_value
 
 
@@ -77,6 +81,8 @@ def single_var_grad_optim(
         if isinstance(variable, InputDiscreteVariable):
             continue
         result = solve_gd_for_1var(new_solution, variables, var_idx, fcn)
-        new_value = result.solution_score
         new_solution = result.solution_vector
+    # Re-evaluate once at the final vector so the stored (vector, value) pair is
+    # exactly consistent (see full_grad_optim for the rationale).
+    new_value = fcn(new_solution)
     return new_solution, new_value

--- a/src/optimizers/continuous/pso.py
+++ b/src/optimizers/continuous/pso.py
@@ -15,6 +15,7 @@ from ..solution_deck import (
     SolutionDeck,
 )
 from .base import IOptimizer, check_stop_early, GoalFcn, InputArguments
+from ..core.random import rng as global_rng
 
 
 @dataclass
@@ -48,50 +49,55 @@ def run_particles(
     solutions (p-best from archive, g-best as current best) with velocity clamping.
     """
     # Lifted from: https://en.wikipedia.org/wiki/Particle_swarm_optimization#Algorithm
-    # Precompute the initial vector for each particle
-    p_best_pos = np.zeros((n_particles, len(variables)))  # Best Position
-    p_pos = np.zeros((n_particles, len(variables)))  # Current Position
-    p_vel = np.zeros((n_particles, len(variables)))  # Current Velocity
-    p_best_val = np.zeros(n_particles)  # Particle best value
-    # Swarm best position
-    for k in range(n_particles):
-        for d, v in enumerate(variables):
-            p_pos[k, d] = p_best_pos[k, d] = v.initial_random_value()
-            p_vel[k, d] = v.initial_random_velocity()
-        p_best_val[k] = fcn(p_best_pos[k, :])
+    rng = global_rng()
+    n_vars = len(variables)
+    # Per-variable domains, used to clamp velocity (constant across the run).
+    domains = np.array([v.domain for v in variables])
+
+    # Vectorized initialization: fill each variable's column for all particles at
+    # once (loop over the few variables, not the many particles). See report #5.
+    p_best_pos = np.empty((n_particles, n_vars))  # Best Position
+    p_vel = np.empty((n_particles, n_vars))  # Current Velocity
+    for d, v in enumerate(variables):
+        p_best_pos[:, d] = v.initial_random_values(n_particles, rng=rng)
+        p_vel[:, d] = v.initial_random_velocities(n_particles, rng=rng)
+    p_pos = p_best_pos.copy()  # Current Position starts at the initial best
+    p_best_val = np.array([fcn(p_best_pos[k, :]) for k in range(n_particles)])
+
     # Get the best position
     best_idx = np.argmin(p_best_val)
-    swarm_best_pos = p_best_pos[best_idx, :]
+    swarm_best_pos = p_best_pos[best_idx, :].copy()
     swarm_best_val = p_best_val[best_idx]
     if global_best_value < swarm_best_val:
         swarm_best_val = global_best_value
-        swarm_best_pos = global_best_position
+        swarm_best_pos = np.asarray(global_best_position).copy()
 
     n_iterations = 10
     for cur_iter in range(n_iterations):
-        for d, v in enumerate(variables):
-            r_p, r_g = np.random.rand(), np.random.rand()
-            # Update velocity
-            p_vel[:, d] = (
-                inertia * p_vel[:, d]
-                + r_p * cognitive * (p_best_pos[:, d] - p_pos[:, d])
-                + social * r_g * (swarm_best_pos[d] - p_pos[:, d])
-            )
-            # Clamp the velocity
-            p_vel[:, d] *= np.minimum(
-                np.maximum(p_vel[:, d] / v.domain, -velocity_clamp), velocity_clamp
-            )
+        # One (r_p, r_g) per dimension (matching the original), applied across
+        # all particles at once via broadcasting.
+        r_p = rng.random(n_vars)
+        r_g = rng.random(n_vars)
+        p_vel = (
+            inertia * p_vel
+            + r_p * cognitive * (p_best_pos - p_pos)
+            + social * r_g * (swarm_best_pos[None, :] - p_pos)
+        )
+        # Clamp the velocity (same per-dimension ratio clamp as before).
+        p_vel *= np.minimum(
+            np.maximum(p_vel / domains, -velocity_clamp), velocity_clamp
+        )
         # Update the particle position for this time step.
         p_pos += p_vel
-        # Do the best position for each particle
-        for k in range(n_particles):
-            new_val = fcn(p_pos[k, :])
-            if new_val < p_best_val[k]:
-                p_best_val[k] = new_val
-                p_best_pos[k, :] = p_pos[k, :]
-            if new_val < swarm_best_val:
-                swarm_best_val = new_val
-                swarm_best_pos = p_pos[k, :]
+        # Evaluate all particles, then update personal/swarm bests vectorized.
+        new_vals = np.array([fcn(p_pos[k, :]) for k in range(n_particles)])
+        improved = new_vals < p_best_val
+        p_best_val = np.where(improved, new_vals, p_best_val)
+        p_best_pos[improved] = p_pos[improved]
+        iter_best = int(np.argmin(new_vals))
+        if new_vals[iter_best] < swarm_best_val:
+            swarm_best_val = new_vals[iter_best]
+            swarm_best_pos = p_pos[iter_best, :].copy()
     # Return the positions and values
     return OptimizerRun(population_values=p_best_val, population_solutions=p_best_pos)
 

--- a/src/optimizers/continuous/variables.py
+++ b/src/optimizers/continuous/variables.py
@@ -46,6 +46,27 @@ class InputDiscreteVariable(InputVariable):
             return rng.choice(self.values, p=p_count)
         return rng.choice(self.values)
 
+    def random_values(
+        self,
+        current_values: AF,
+        other_values: Optional[AF] = None,
+        learning_rate: float = 0.7,
+        rng: Generator | None = None,
+    ) -> AF:
+        # The discrete weighting depends only on the archive column, not on the
+        # per-entry current value, so build the probability vector ONCE and draw
+        # all samples in a single rng.choice instead of running np.unique per
+        # sample. See report item #15.
+        if rng is None:
+            rng = global_rng()
+        n = np.asarray(current_values).shape[0]
+        if other_values is not None:
+            all_values = np.concatenate((self.values, other_values))
+            unique, counts = np.unique(all_values, return_counts=True)
+            p_count = counts / np.sum(counts)
+            return rng.choice(self.values, size=n, p=p_count)
+        return rng.choice(self.values, size=n)
+
     def initial_random_value(self, perturbation: float = 0.1) -> F | I:
         rng = global_rng()
         return rng.choice(self.values)
@@ -149,6 +170,38 @@ class InputContinuousVariable(InputVariable):
                 rng=rng,
             )
         return rng.uniform(self.lower_bound, self.upper_bound)
+
+    def random_values(
+        self,
+        current_values: AF,
+        other_values: Optional[AF] = None,
+        learning_rate: float = 0.7,
+        rng: Generator | None = None,
+    ) -> AF:
+        # Vectorized truncated-normal sampling: one draw per entry of
+        # current_values, each centered on its own value with spread derived
+        # from the (shared) archive column. Equivalent to calling random_value
+        # once per entry, but done as array ops. See report item #5.
+        if rng is None:
+            rng = global_rng()
+        cv = np.asarray(current_values, dtype=float)
+        if other_values is None:
+            return rng.uniform(self.lower_bound, self.upper_bound, size=cv.shape)
+        # Mean absolute deviation of the archive column from each center.
+        d2 = np.mean(np.abs(other_values[None, :] - cv[:, None]), axis=1)
+        stdev = learning_rate * d2
+        stdev = np.where(stdev <= 0.0, 1.0, stdev)
+        low, high = self.lower_bound, self.upper_bound
+        a = ndtr((low - cv) / stdev)
+        b = ndtr((high - cv) / stdev)
+        span = b - a
+        # Avoid a zero-width window for degenerate centers; sampled below.
+        safe_span = np.where(span <= 0.0, 1.0, span)
+        u = a + rng.uniform(size=cv.shape) * safe_span
+        x = cv + stdev * ndtri(u)
+        # Degenerate windows fall back to the clamped center.
+        x = np.where(span <= 0.0, cv, x)
+        return np.clip(x, low, high)
 
     def initial_random_value(
         self, perturbation: float = 0.1, rng: Generator | None = None

--- a/src/optimizers/continuous/variables.py
+++ b/src/optimizers/continuous/variables.py
@@ -30,6 +30,16 @@ class InputDiscreteVariable(InputVariable):
         # Just randomly tweak to another choice.
         return self.initial_random_value()
 
+    def perturb_values(
+        self, current_values: AF, perturbation: float = 0.1, rng: Generator | None = None
+    ) -> AF:
+        # Perturbing a discrete variable just re-draws a random choice, so draw
+        # the whole population at once.
+        if rng is None:
+            rng = global_rng()
+        n = np.asarray(current_values).shape[0]
+        return rng.choice(self.values, size=n)
+
     def random_value(
         self,
         current_value: F | I = np.nan,
@@ -123,6 +133,20 @@ class InputContinuousVariable(InputVariable):
         sigma = self.domain * perturbation
         new_value = current_value + sigma * global_rng().normal()
         return max(min(self.upper_bound, new_value), self.lower_bound)
+
+    def perturb_values(
+        self, current_values: AF, perturbation: float = 0.1, rng: Generator | None = None
+    ) -> AF:
+        # Vectorized gaussian perturbation for a whole population at once.
+        if rng is None:
+            rng = global_rng()
+        cv = np.asarray(current_values, dtype=float)
+        sigma = self.domain * perturbation
+        return np.clip(
+            cv + sigma * rng.normal(size=cv.shape),
+            self.lower_bound,
+            self.upper_bound,
+        )
 
     def __get_truncated_normal(
         self,

--- a/src/optimizers/continuous/variables.py
+++ b/src/optimizers/continuous/variables.py
@@ -81,6 +81,13 @@ class InputDiscreteVariable(InputVariable):
         rng = global_rng()
         return rng.choice(self.values)
 
+    def initial_random_values(
+        self, n: int, perturbation: float = 0.1, rng: Generator | None = None
+    ) -> AF:
+        if rng is None:
+            rng = global_rng()
+        return rng.choice(self.values, size=n)
+
     def range_value(self, p: float) -> F | I:
         # Map p in [0,1] to the discrete values
         idx = int(p * len(self.values))
@@ -233,6 +240,13 @@ class InputContinuousVariable(InputVariable):
         if rng is None:
             rng = global_rng()
         return rng.uniform(self.lower_bound, self.upper_bound)
+
+    def initial_random_values(
+        self, n: int, perturbation: float = 0.1, rng: Generator | None = None
+    ) -> AF:
+        if rng is None:
+            rng = global_rng()
+        return rng.uniform(self.lower_bound, self.upper_bound, size=n)
 
     def range_value(self, p: float) -> float:
         # Map p in [0,1] to the variable range

--- a/src/optimizers/continuous/variables.py
+++ b/src/optimizers/continuous/variables.py
@@ -2,7 +2,7 @@ from typing import Optional
 
 import numpy as np
 from numpy.random import Generator
-from scipy.stats import truncnorm
+from scipy.special import ndtr, ndtri
 
 from ..core.types import AF, AI, F, I
 from ..core.variables import InputVariable
@@ -103,12 +103,33 @@ class InputContinuousVariable(InputVariable):
         new_value = current_value + sigma * global_rng().normal()
         return max(min(self.upper_bound, new_value), self.lower_bound)
 
-    def __get_truncated_normal(self, mean=0.0, stdev=1.0, low=0.0, high=10.0) -> float:
-        if stdev == 0.0:
+    def __get_truncated_normal(
+        self,
+        mean=0.0,
+        stdev=1.0,
+        low=0.0,
+        high=10.0,
+        rng: Generator | None = None,
+    ) -> float:
+        # Inverse-CDF (Gaussian) sampling of a truncated normal. This avoids
+        # constructing a scipy ``truncnorm`` frozen distribution on every call
+        # (which spent ~60% of ACO runtime building docstrings); the draw is
+        # statistically identical. See PERFORMANCE_REPORT.md item #1.
+        if stdev <= 0.0:
             stdev = 1.0
-        return truncnorm(
-            (low - mean) / stdev, (high - mean) / stdev, loc=mean, scale=stdev
-        ).rvs()
+        if rng is None:
+            rng = global_rng()
+        a = ndtr((low - mean) / stdev)
+        b = ndtr((high - mean) / stdev)
+        if b <= a:
+            # Degenerate window (mean far outside [low, high]); fall back to the
+            # nearer bound rather than dividing a zero-width interval.
+            return float(min(max(mean, low), high))
+        u = rng.uniform(a, b)
+        x = mean + stdev * ndtri(u)
+        # ndtri can return +/-inf at the extreme tails; clamp to the domain so
+        # the result is always within [low, high] as truncnorm guaranteed.
+        return float(min(max(x, low), high))
 
     def random_value(
         self,
@@ -116,7 +137,7 @@ class InputContinuousVariable(InputVariable):
         other_values: Optional[AF] = None,
         learning_rate: float = 0.7,
     ):
-        rng = np.random.default_rng()
+        rng = global_rng()
         if other_values is not None:
             # TODO - Other than Manhattan distance, what other distance metrics can be used?
             d2 = np.sum(np.abs(other_values - current_value)) / len(other_values)
@@ -125,6 +146,7 @@ class InputContinuousVariable(InputVariable):
                 stdev=learning_rate * d2,
                 low=self.lower_bound,
                 high=self.upper_bound,
+                rng=rng,
             )
         return rng.uniform(self.lower_bound, self.upper_bound)
 
@@ -132,7 +154,7 @@ class InputContinuousVariable(InputVariable):
         self, perturbation: float = 0.1, rng: Generator | None = None
     ) -> float:
         if rng is None:
-            rng = np.random.default_rng()
+            rng = global_rng()
         return rng.uniform(self.lower_bound, self.upper_bound)
 
     def range_value(self, p: float) -> float:

--- a/src/optimizers/core/variables.py
+++ b/src/optimizers/core/variables.py
@@ -4,6 +4,7 @@ from dataclasses import dataclass
 import numpy as np
 from typing import Optional, List
 from .types import af64
+from .random import rng as global_rng
 
 
 class InputVariable(ABC):
@@ -61,6 +62,14 @@ class InputVariable(ABC):
     def initial_random_value(self, perturbation: float = 0.1) -> float:
         pass
 
+    def initial_random_values(
+        self, n: int, perturbation: float = 0.1, rng=None
+    ) -> af64:
+        """Vectorized ``initial_random_value`` — draw ``n`` fresh values. Base
+        implementation loops; numeric subclasses override.
+        """
+        return np.array([self.initial_random_value(perturbation) for _ in range(n)])
+
     @abstractmethod
     def range_value(self, p: float) -> float:
         pass
@@ -81,7 +90,13 @@ class InputVariable(ABC):
 
     def initial_random_velocity(self) -> float:
         # NOTE - This doesn't mean as much for discrete variables, so we should probably ignore them?
-        return np.random.uniform(-self.domain, self.domain)
+        return global_rng().uniform(-self.domain, self.domain)
+
+    def initial_random_velocities(self, n: int, rng=None) -> af64:
+        """Vectorized ``initial_random_velocity`` — draw ``n`` velocities."""
+        if rng is None:
+            rng = global_rng()
+        return rng.uniform(-self.domain, self.domain, size=n)
 
 
 # Type hinting

--- a/src/optimizers/core/variables.py
+++ b/src/optimizers/core/variables.py
@@ -20,6 +20,25 @@ class InputVariable(ABC):
     ) -> float:
         pass
 
+    def random_values(
+        self,
+        current_values: af64,
+        other_values: Optional[af64] = None,
+        learning_rate: float = 0.7,
+        rng=None,
+    ) -> af64:
+        """Vectorized ``random_value`` — draw one sample per entry of
+        ``current_values``. The base implementation loops (safe for any custom
+        subclass); numeric subclasses override it with a vectorized version so a
+        whole ant population can be sampled per variable in one call.
+        """
+        return np.array(
+            [
+                self.random_value(cv, other_values, learning_rate)
+                for cv in np.asarray(current_values)
+            ]
+        )
+
     @abstractmethod
     def perturb_value(self, current_value: float, perturbation: float = 0.1) -> float:
         pass

--- a/src/optimizers/core/variables.py
+++ b/src/optimizers/core/variables.py
@@ -43,6 +43,20 @@ class InputVariable(ABC):
     def perturb_value(self, current_value: float, perturbation: float = 0.1) -> float:
         pass
 
+    def perturb_values(
+        self, current_values: af64, perturbation: float = 0.1, rng=None
+    ) -> af64:
+        """Vectorized ``perturb_value`` — perturb each entry of
+        ``current_values``. Base implementation loops; numeric subclasses
+        override with a vectorized version.
+        """
+        return np.array(
+            [
+                self.perturb_value(cv, perturbation)
+                for cv in np.asarray(current_values)
+            ]
+        )
+
     @abstractmethod
     def initial_random_value(self, perturbation: float = 0.1) -> float:
         pass

--- a/src/optimizers/solution_deck.py
+++ b/src/optimizers/solution_deck.py
@@ -143,6 +143,23 @@ class SolutionDeck:
         self.solution_value = self.solution_value[idx]
         self.is_local_optima = self.is_local_optima[idx]
 
+    def truncate(self, size: int = -1) -> None:
+        """Keep only the best ``size`` entries, dropping the rest.
+
+        Assumes the deck is already sorted best-first (``sort``/``deduplicate``
+        leave it sorted). Without this the archive grows by ~``population_size``
+        every generation forever, so every subsequent sort/dedup/CDF runs over an
+        ever-larger array. Bounding it to ``archive_size`` restores the intended
+        fixed-size elitist archive. See PERFORMANCE_REPORT.md item #3.
+        """
+        if size < 0:
+            size = self.archive_size
+        if size <= 0 or self.solution_archive.shape[0] <= size:
+            return
+        self.solution_archive = self.solution_archive[:size]
+        self.solution_value = self.solution_value[:size]
+        self.is_local_optima = self.is_local_optima[:size]
+
     def __len__(self) -> int:
         return self.solution_archive.shape[0]
 


### PR DESCRIPTION
**Stacked on #71** (targets `perf/5-ga-vectorize`).

Applies the **same optimizations as the ACO/GA PRs** to the PSO, completing GA/PSO parity. **~3.3× faster** single-worker PSO (0.71s → 0.21s).

## Changes
- **Vectorized `run_particles`** (`pso.py`):
  - Initialization fills each variable's column for all particles at once (loop over the few variables), not a per-particle, per-dimension scalar loop.
  - Velocity update is a single whole-array expression — one `(r_p, r_g)` per dimension broadcast across particles (matching the original semantics); per-variable domains precomputed once for the clamp.
  - Personal/swarm-best updates vectorized after one evaluation pass; only the goal-function evaluation stays per-particle.
- **Shared RNG** (`pso.py`) — draw randomness from the shared seedable `global_rng()` instead of `np.random.*`. PSO half of report **#4**: **verified deterministic under `set_seed()`**.
- **Batch init methods** (`variables.py`, `core/variables.py`) — `initial_random_values`, `initial_random_velocities` (+ safe looping defaults); `initial_random_velocity` now uses the shared RNG.

## Verification
- 30 runs across Ackley + Rosenbrock: **0** `(vector, value)` invariant failures.
- Reproducible under `set_seed()`.
- Non-cluster suite: **21 passed**.

## Stack recap (this batch)
#69 deck (ACO/PSO/GA) → #70 ACO vectorize → #71 GA vectorize → **this** PSO vectorize.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DoXi5fcpttwqEDjgS2WL6h