### PR TITLE
perf(parallel): ship run-constant data to workers once per run

### DIFF
--- a/PERFORMANCE_REPORT.md
+++ b/PERFORMANCE_REPORT.md
@@ -71,19 +71,27 @@ Behavior is statistically identical. This also removes the scipy `truncnorm` imp
 
 ---
 
-### 2. Copy fixed data to workers **once**, not every generation *(your flagged item)*
-**Files:** `src/optimizers/continuous/aco.py:114-125`, `pso.py:140-153`, `ga.py:154-166`; `src/optimizers/core/base.py:68-77` (`setup_for_generations`)
+### 2. Copy fixed data to workers **once**, not every generation *(your flagged item)* — ✅ IMPLEMENTED
+**Files:** `src/optimizers/core/parallel.py` (new `GenerationRunner`); `src/optimizers/continuous/aco.py`, `pso.py`, `ga.py` (each `solve()` now builds a `fixed` payload once and dispatches only varying args); `src/optimizers/continuous/base.py` (`live_meta`, `sync_worker_meta`).
 
-Today every generation calls `parallel(joblib.delayed(run_ants)(..., self.variables, self.wrapped_fcn, self.soln_deck.solution_archive))`. With `joblib_prefer="processes"`, joblib **pickles and ships every argument to every worker on every generation** — including the `variables` list, the wrapped goal function (which closes over `args`, i.e. your large fixed dataset), and the archive.
+Previously every generation called `parallel(joblib.delayed(run_ants)(..., self.variables, self.wrapped_fcn, self.soln_deck.solution_archive))`. With `joblib_prefer="processes"`, joblib **pickles and ships every argument to every worker on every generation** — including the `variables` list, the wrapped goal function (which closes over `args`, i.e. your large fixed dataset), and the archive.
 
-**Evidence:** re-pickling a 16 MB fixed array for a 25-gen × 4-job run costs **0.57 s just in serialization** (5.7 ms per dispatch), before any transport or fitness work. For the large datasets you describe, this scales linearly and dominates.
+**What shipped.** A shared `GenerationRunner` splits arguments into **fixed** (constant for the whole run: `variables`, wrapped goal fn, hyper-parameters — the goal fn closes over your large `args` dataset) and **varying** (the bounded archive + rank CDF, small). For the `processes` backend it owns a dedicated `loky.ProcessPoolExecutor` whose **initializer stashes the fixed payload once per worker** (keyed by an opaque token in a module global); each generation then dispatches only the small varying args. `cloudpickle` handles the goal-fn closure. ACO/PSO/GA all route through this one helper.
 
-**Fix — send the immutable data once.** Two complementary approaches, both general:
+**Evidence (measured on your hardware, 3 workers).** The re-ship cost is *per generation*, so it scales with generation count while ship-once stays flat:
 
-- **Persistent worker pool + initializer.** Replace the per-generation `joblib.delayed` fan-out with a `loky` reusable executor (or `concurrent.futures.ProcessPoolExecutor`) created once at `solve()` start, with an `initializer` that stashes the fixed payload (`variables`, `args`, goal fn) in a module global on each worker. Per generation you then dispatch only the *changing* data (the current archive, or just its indices). joblib's `loky` backend already keeps workers warm across `parallel()` calls when you reuse a single `Parallel(backend="loky")` instance — the missing piece is not re-sending the constant args.
-- **Memory-map large read-only arrays.** For big numpy payloads, hand workers a `np.memmap` (or rely on joblib's `max_nbytes` auto-memmap, which kicks in >1 MB) so the OS shares one physical copy across processes instead of pickling N copies. This is the lowest-risk way to stop replicating "a large section of memory."
+| generations | old (re-ship/gen) | new (ship-once) | speedup |
+|---:|---:|---:|---:|
+| 12 | 2.24 s | 2.33 s | 0.96× |
+| 30 | 5.38 s | 2.33 s | **2.3×** |
+| 60 | 10.83 s | 2.38 s | **4.6×** |
+| 100 | 18.12 s | 2.40 s | **7.5×** |
 
-Design note: the current code is *structurally* ready for this — the fixed args (`variables`, `wrapped_fcn`) never change during a solve, and only `solution_archive` mutates per generation. Factor the parallel dispatch into a small reusable helper so ACO/PSO/GA share one implementation.
+(non-memmappable ~30 MB Python-object payload closed over by the goal fn). Crossover is ~12 generations; the default `num_generations=50` sits squarely in the win zone, and the gap widens with run length.
+
+**Important nuance — memmap vs. Python objects.** joblib's `loky` backend **already auto-memmaps large numpy arrays** (`max_nbytes`, default 1 MB) *even when nested inside a closure*, so for a purely-numpy fixed dataset the old path was already near-optimal and ship-once gives only a small edge. The large, generation-scaling win is for **non-array Python payloads** — dicts, lists, pandas objects, custom classes — which joblib must fully re-pickle every generation. `GenerationRunner` eliminates that regardless of payload type.
+
+**Tradeoff.** The dedicated pool is spawned per `solve()` (a ~0.5–0.7 s one-time cost, amortized across the run) rather than reusing loky's process-global warm pool — deliberately, because sharing that global singleton collides with `joblib.Parallel(prefer="processes")` used by gradient descent (`AttributeError: ... _temp_folder_manager`). Isolation is worth the amortized spawn.
 
 ---
 
@@ -166,15 +174,15 @@ The iVAT reordering recursion (`for r in range(1,N): for c in range(r): ...`) is
 
 ---
 
-### 11. Choose threads vs processes correctly — and document it
-**Files:** `src/optimizers/core/base.py:106` (`joblib_prefer="threads"` default), all `solve()` methods
+### 11. Choose threads vs processes correctly — and document it — ✅ IMPLEMENTED (guidance) 
+**Files:** `src/optimizers/core/base.py:106` (`joblib_prefer="threads"` default), all `solve()` methods, `src/optimizers/core/parallel.py` (`GenerationRunner` docstring documents the tradeoff at the point of use).
 
 The default is `"threads"`. The inner worker bodies (`run_ants`, `run_ga`, ACO tour construction) are **largely pure Python**, so under the GIL threads give little speedup and add dispatch overhead. Threads only win when the fitness function is numpy-vectorized (releases the GIL) or you're on a free-threaded build (`sample.py` already probes `sys._is_gil_enabled()`).
 
-**Guidance to bake in:**
-- **CPU-bound pure-Python fitness →** `processes` (with #2 so fixed data isn't re-shipped).
-- **numpy-vectorized fitness / free-threaded 3.13t →** `threads` (no pickling, shared memory).
-- Document this tradeoff in the config docstring and pick a smarter default (e.g. `processes` when a large `args` payload is detected, else `threads`). Keep it a user-visible knob — it's workload-dependent.
+**Guidance (now encoded in `GenerationRunner` — one helper handles both backends):**
+- **CPU-bound pure-Python fitness →** `processes` (ship-once via #2 so fixed data isn't re-shipped).
+- **numpy-vectorized fitness / free-threaded 3.13t →** `threads` (no pickling, shared memory; `fixed` passed by reference).
+- The tradeoff is documented in the `GenerationRunner` docstring at the point of use. `joblib_prefer` stays a user-visible knob — it's workload-dependent. A future refinement (not yet done) is auto-selecting `processes` when a large `args` payload is detected.
 
 ---
 

--- a/PERF_PLAN.md
+++ b/PERF_PLAN.md
@@ -16,8 +16,12 @@ it is being split into a separate package. Report items #8 (FCM) and #9 (iVAT) a
 | 2 | `perf/2-continuous-quickwins` | PR1 | #1 truncnorm sampling, #4 RNG reuse, #14 `bump_eval` overhead | low |
 | 3 | `perf/3-solution-deck` | PR2 | #3 bound archive to `archive_size`, #12 sort/dedup once per gen | low |
 | 4 | `perf/4-aco-vectorize` | PR3 | #5 vectorize `run_ants` + hoist CDF, #15 discrete `random_value` | med |
-| 5 | `perf/5-parallel-arch` | PR4 | #2 send fixed data to workers once, #11 threads/processes guidance | med |
-| 6 | `perf/6-combinatorial` | PR5 | #6 precompute `eta**beta`/`tau**alpha`, #7 GA `vstack`, #10 vectorize distance/deposit, #13 njit local search | med |
+| 5 | `perf/5-ga-vectorize` | PR4 | GA: vectorized tournament/crossover/mutation + shared RNG | med |
+| 6 | `perf/6-pso-vectorize` | PR5 | PSO: vectorized init/velocity/eval + shared RNG | med |
+| 7 | `perf/7-parallel-arch` | PR6 | #2 send fixed data to workers once, #11 threads/processes guidance | med |
+| 8 | `perf/8-combinatorial` | PR7 | #6 precompute `eta**beta`/`tau**alpha`, #7 GA `vstack`, #10 vectorize distance/deposit, #13 njit local search | med |
+
+> Note: PRs 5/6 were split out to mirror the ACO vectorization (PR4) onto GA and PSO individually, which pushed the parallel-architecture and combinatorial work down to PR7/PR8.
 
 Each PR:
 - keeps changes **general and flexible** (no problem-specific assumptions);
@@ -39,7 +43,9 @@ Each PR:
    suite fast, which speeds up every subsequent PR's verification.
 2. **Solution deck** (PR3) — removes unbounded growth so later benchmarks are stable.
 3. **ACO vectorization** (PR4) — builds on the faster sampling primitive from PR2.
-4. **Parallel architecture** (PR5) — the "copy fixed data once" refactor; benefits from a
+4. **GA / PSO vectorization** (PR5/PR6) — mirror the ACO vectorization onto the other
+   two continuous solvers so they all share the fast, batched worker shape.
+5. **Parallel architecture** (PR7) — the "copy fixed data once" refactor; benefits from a
    clean, bounded deck and vectorized workers underneath it.
-5. **Combinatorial** (PR6) — independent of the continuous stack; lands last so its
+6. **Combinatorial** (PR8) — independent of the continuous stack; lands last so its
    larger surface area doesn't block the high-value continuous fixes.

--- a/src/optimizers/continuous/aco.py
+++ b/src/optimizers/continuous/aco.py
@@ -12,7 +12,8 @@ from ..core.base import (
     GoalFcn,
     InputArguments,
 )
-from ..continuous.base import check_stop_early, cdf
+from ..continuous.base import check_stop_early, cdf, sync_worker_meta
+from ..core.parallel import GenerationRunner
 from ..core.types import af64
 from ..solution_deck import (
     SolutionDeck,
@@ -33,20 +34,15 @@ class AntColonyOptimizerConfig(IOptimizerConfig):
 
 
 def run_ants(
-    n_ants: int,
-    q_weight: float,
-    learning_rate: float,
-    local_optim: LocalOptimType,
+    fixed: tuple,
+    meta: dict,
     solution_archive: af64,
-    variables: InputVariables,
-    fcn: WrappedGoalFcn,
-    cp_j: af64 | None = None,
+    cp_j: af64,
 ) -> OptimizerRun:
-    # The rank CDF depends only on q and the (bounded) archive length, so it is
-    # computed once per generation in solve() and passed in; recompute only as a
-    # fallback. See report item #5.
-    if cp_j is None:
-        cp_j = cdf(q_weight, len(solution_archive))
+    # ``fixed`` is the run-constant payload shipped to each worker once (see
+    # core.parallel); ``meta`` is the small per-generation live metadata.
+    arg_provider, variables, fcn, learning_rate, local_optim, n_ants = fixed
+    sync_worker_meta(arg_provider, meta)
     n_vars = len(variables)
     rng = global_rng()
 
@@ -111,36 +107,41 @@ class AntColonyOptimizer(IOptimizer):
             parallel,
             stopped_early,
         ) = self.initialize(preserve_percent)
-        for generations_completed in generation_pbar:
-            # Update runtime metadata for this generation
-            self._set_phase("evolve")
-            self._set_generation(generations_completed)
+        # Fixed data (variables, wrapped goal fn, hyper-parameters) is shipped to
+        # each worker exactly once; only the archive + CDF vary per generation.
+        fixed = (
+            self._arg_provider,
+            self.variables,
+            self.wrapped_fcn,
+            self.config.learning_rate,
+            self.config.local_grad_optim,
+            individuals_per_job,
+        )
+        runner = GenerationRunner(n_jobs, self.config.joblib_prefer, fixed)
+        try:
+            for generations_completed in generation_pbar:
+                # Update runtime metadata for this generation
+                self._set_phase("evolve")
+                self._set_generation(generations_completed)
 
-            stopped_early = check_stop_early(
-                self.config, best_soln_history, self.soln_deck.solution_value
-            )
-            if stopped_early != "none":
-                break
-
-            # Compute the rank CDF once per generation (not once per worker).
-            cp_j = cdf(self.config.q, len(self.soln_deck.solution_archive))
-            job_output: list[OptimizerRun] = parallel(
-                joblib.delayed(run_ants)(
-                    individuals_per_job,
-                    self.config.q,
-                    self.config.learning_rate,
-                    self.config.local_grad_optim,
-                    self.soln_deck.solution_archive,
-                    self.variables,
-                    self.wrapped_fcn,
-                    cp_j,
+                stopped_early = check_stop_early(
+                    self.config, best_soln_history, self.soln_deck.solution_value
                 )
-                for _ in range(n_jobs)
-            )
+                if stopped_early != "none":
+                    break
 
-            # Merge candidates into the archive
-            self.update_solution_deck(generation_pbar, job_output)
-            best_soln_history.append(self.soln_deck.get_best()[1])
+                # Compute the rank CDF once per generation (not once per worker).
+                cp_j = cdf(self.config.q, len(self.soln_deck.solution_archive))
+                job_output: list[OptimizerRun] = runner.run(
+                    run_ants,
+                    (self.live_meta(), self.soln_deck.solution_archive, cp_j),
+                )
+
+                # Merge candidates into the archive
+                self.update_solution_deck(generation_pbar, job_output)
+                best_soln_history.append(self.soln_deck.get_best()[1])
+        finally:
+            runner.close()
         # Mark finalize phase
         self._set_phase("finalize")
         stopped_early = stopped_early if stopped_early != "none" else "max_iterations"

--- a/src/optimizers/continuous/base.py
+++ b/src/optimizers/continuous/base.py
@@ -122,6 +122,16 @@ class IOptimizer(abc.ABC):
             num_vars=len(variables),
         )
 
+    def live_meta(self) -> InputArguments:
+        """The per-generation runtime metadata that changes during the run.
+
+        The rest of the metadata (run_id, max_generation, population_size, ...)
+        is constant and ships with the goal function once, so only these live
+        fields need to be re-synced to worker processes each generation.
+        """
+        meta = self._arg_provider.meta
+        return {"generation": meta.get("generation"), "phase": meta.get("phase")}
+
     def _set_phase(self, phase: Phase) -> None:
         # Validate at runtime for extra safety in non-type-checked contexts
         try:
@@ -208,6 +218,18 @@ class IOptimizer(abc.ABC):
 
     def __str__(self):
         return f"Solver(name={self.config.name})"
+
+
+def sync_worker_meta(arg_provider, meta: Optional[InputArguments]) -> None:
+    """Apply the parent's live metadata snapshot to a worker's arg provider.
+
+    In the ``processes`` backend each worker holds its own copy of the arg
+    provider (shipped once with the goal function), so the optimizer passes the
+    small live-metadata dict each generation and the worker merges it here before
+    evaluating the goal function.
+    """
+    if arg_provider is not None and meta:
+        arg_provider.meta.update(meta)
 
 
 def check_stop_early(

--- a/src/optimizers/continuous/ga.py
+++ b/src/optimizers/continuous/ga.py
@@ -15,9 +15,11 @@ from ..core.base import (
 )
 from .base import (
     check_stop_early,
+    sync_worker_meta,
 )
 from ..core.variables import InputVariables
 from ..core.random import rng as global_rng
+from ..core.parallel import GenerationRunner
 from .base import IOptimizer
 
 from ..solution_deck import (
@@ -90,15 +92,23 @@ def _mutate_batch(
 
 
 def run_ga(
-    n_steps: int,
-    mutation_rate: float,
-    crossover_rate: float,
-    local_optim: LocalOptimType,
+    fixed: tuple,
+    meta: dict,
     solution_values: AF | AI,
     solution_archive: AF,
-    variables: InputVariables,
-    fcn: WrappedGoalFcn,
 ) -> OptimizerRun:
+    # ``fixed`` is shipped to each worker once; ``meta`` is the small per-
+    # generation live metadata. See core.parallel.
+    (
+        arg_provider,
+        variables,
+        fcn,
+        mutation_rate,
+        crossover_rate,
+        local_optim,
+        n_steps,
+    ) = fixed
+    sync_worker_meta(arg_provider, meta)
     rng = global_rng()
     # Vectorize the genetic operators across the whole batch of offspring; only
     # evaluation / local search stays per-individual (scalar goal function).
@@ -159,34 +169,44 @@ class GeneticAlgorithmOptimizer(IOptimizer):
             parallel,
             stopped_early,
         ) = self.initialize(preserve_percent)
-        for generations_completed in generation_pbar:
-            # Update runtime metadata for this generation
-            self._set_phase("evolve")
-            self._set_generation(generations_completed)
+        # Ship fixed data (variables, goal fn, GA hyper-parameters) to each
+        # worker once; only the archive + fitness vary per generation.
+        fixed = (
+            self._arg_provider,
+            self.variables,
+            self.wrapped_fcn,
+            self.config.mutation_rate,
+            self.config.crossover_rate,
+            self.config.local_grad_optim,
+            individuals_per_job,
+        )
+        runner = GenerationRunner(n_jobs, self.config.joblib_prefer, fixed)
+        try:
+            for generations_completed in generation_pbar:
+                # Update runtime metadata for this generation
+                self._set_phase("evolve")
+                self._set_generation(generations_completed)
 
-            stopped_early = check_stop_early(
-                self.config, best_soln_history, self.soln_deck.solution_value
-            )
-            if stopped_early != "none":
-                break
-
-            job_output: list[OptimizerRun] = parallel(
-                joblib.delayed(run_ga)(
-                    individuals_per_job,
-                    local_optim=self.config.local_grad_optim,
-                    mutation_rate=self.config.mutation_rate,
-                    crossover_rate=self.config.crossover_rate,
-                    solution_values=self.soln_deck.solution_value,
-                    solution_archive=self.soln_deck.solution_archive,
-                    variables=self.variables,
-                    fcn=self.wrapped_fcn,
+                stopped_early = check_stop_early(
+                    self.config, best_soln_history, self.soln_deck.solution_value
                 )
-                for _ in range(n_jobs)
-            )
+                if stopped_early != "none":
+                    break
 
-            # Merge candidates into the archive
-            self.update_solution_deck(generation_pbar, job_output)
-            best_soln_history.append(self.soln_deck.get_best()[1])
+                job_output: list[OptimizerRun] = runner.run(
+                    run_ga,
+                    (
+                        self.live_meta(),
+                        self.soln_deck.solution_value,
+                        self.soln_deck.solution_archive,
+                    ),
+                )
+
+                # Merge candidates into the archive
+                self.update_solution_deck(generation_pbar, job_output)
+                best_soln_history.append(self.soln_deck.get_best()[1])
+        finally:
+            runner.close()
 
         # Mark finalize phase
         self._set_phase("finalize")

--- a/src/optimizers/continuous/pso.py
+++ b/src/optimizers/continuous/pso.py
@@ -14,8 +14,15 @@ from ..solution_deck import (
     InputVariables,
     SolutionDeck,
 )
-from .base import IOptimizer, check_stop_early, GoalFcn, InputArguments
+from .base import (
+    IOptimizer,
+    check_stop_early,
+    sync_worker_meta,
+    GoalFcn,
+    InputArguments,
+)
 from ..core.random import rng as global_rng
+from ..core.parallel import GenerationRunner
 
 
 @dataclass
@@ -30,15 +37,10 @@ class ParticleSwarmOptimizerConfig(IOptimizerConfig):
 
 
 def run_particles(
-    n_particles: int,
-    inertia: float,
-    cognitive: float,
-    social: float,
-    velocity_clamp: float,
+    fixed: tuple,
+    meta: dict,
     global_best_position: AF,
     global_best_value: F,
-    variables: InputVariables,
-    fcn: WrappedGoalFcn,
 ) -> OptimizerRun:
     """
     Generate new candidate solutions using a PSO-inspired step that leverages the
@@ -49,6 +51,19 @@ def run_particles(
     solutions (p-best from archive, g-best as current best) with velocity clamping.
     """
     # Lifted from: https://en.wikipedia.org/wiki/Particle_swarm_optimization#Algorithm
+    # ``fixed`` is shipped to each worker once; ``meta`` is the small per-
+    # generation live metadata. See core.parallel.
+    (
+        arg_provider,
+        variables,
+        fcn,
+        inertia,
+        cognitive,
+        social,
+        velocity_clamp,
+        n_particles,
+    ) = fixed
+    sync_worker_meta(arg_provider, meta)
     rng = global_rng()
     n_vars = len(variables)
     # Per-variable domains, used to clamp velocity (constant across the run).
@@ -132,35 +147,45 @@ class ParticleSwarmOptimizer(IOptimizer):
             parallel,
             stopped_early,
         ) = self.initialize(preserve_percent)
-        for generations_completed in generation_pbar:
-            # Update runtime metadata for this generation
-            self._set_phase("evolve")
-            self._set_generation(generations_completed)
+        # Ship fixed data (variables, goal fn, PSO coefficients) to each worker
+        # once; only the current global best varies per generation.
+        fixed = (
+            self._arg_provider,
+            self.variables,
+            self.wrapped_fcn,
+            self.config.inertia,
+            self.config.cognitive,
+            self.config.social,
+            self.config.velocity_clamp,
+            individuals_per_job,
+        )
+        runner = GenerationRunner(n_jobs, self.config.joblib_prefer, fixed)
+        try:
+            for generations_completed in generation_pbar:
+                # Update runtime metadata for this generation
+                self._set_phase("evolve")
+                self._set_generation(generations_completed)
 
-            stopped_early = check_stop_early(
-                self.config, best_soln_history, self.soln_deck.solution_value
-            )
-            if stopped_early != "none":
-                break
-
-            job_output: list[OptimizerRun] = parallel(
-                joblib.delayed(run_particles)(
-                    individuals_per_job,
-                    self.config.inertia,
-                    self.config.cognitive,
-                    self.config.social,
-                    self.config.velocity_clamp,
-                    self.soln_deck.solution_archive[0, :],
-                    self.soln_deck.solution_value[0],
-                    self.variables,
-                    self.wrapped_fcn,
+                stopped_early = check_stop_early(
+                    self.config, best_soln_history, self.soln_deck.solution_value
                 )
-                for _ in range(n_jobs)
-            )
+                if stopped_early != "none":
+                    break
 
-            # Merge candidates into the archive
-            self.update_solution_deck(generation_pbar, job_output)
-            best_soln_history.append(self.soln_deck.get_best()[1])
+                job_output: list[OptimizerRun] = runner.run(
+                    run_particles,
+                    (
+                        self.live_meta(),
+                        self.soln_deck.solution_archive[0, :],
+                        self.soln_deck.solution_value[0],
+                    ),
+                )
+
+                # Merge candidates into the archive
+                self.update_solution_deck(generation_pbar, job_output)
+                best_soln_history.append(self.soln_deck.get_best()[1])
+        finally:
+            runner.close()
 
         # Mark finalize phase
         self._set_phase("finalize")

--- a/src/optimizers/core/parallel.py
+++ b/src/optimizers/core/parallel.py
@@ -1,0 +1,133 @@
+"""Parallel dispatch that ships run-constant data to workers only once.
+
+The optimizers (ACO/PSO/GA) run many generations, each dispatching the same
+worker function ``n_jobs`` times. The arguments split cleanly into:
+
+* **fixed** — constant for the whole run (the input variables, the wrapped goal
+  function, and scalar hyper-parameters). The goal function commonly closes over
+  a large read-only dataset supplied via ``args``.
+* **varying** — changes every generation (the current solution archive, the rank
+  CDF, ...), and is small now that the archive is bounded.
+
+Previously every ``joblib.delayed`` dispatch re-pickled *all* arguments to every
+worker on *every* generation, so a large fixed dataset was replicated to each
+worker process once per generation. ``GenerationRunner`` sends the fixed payload
+to each worker exactly once (via a persistent pool's initializer) and then
+dispatches only the small varying arguments per generation.
+
+See PERFORMANCE_REPORT.md items #2 (copy fixed data once) and #11 (threads vs
+processes).
+"""
+
+import uuid
+from typing import Any, Callable, Sequence
+
+import joblib
+from joblib import cpu_count
+from joblib.externals.loky import ProcessPoolExecutor
+
+# Per-worker cache of run-constant payloads, keyed by an opaque token. Populated
+# once per worker process by the pool initializer. This lives at module scope on
+# purpose: the initializer and the task functions both resolve it by reference in
+# the worker, so the initializer's write is visible to later tasks (a value that
+# was cloudpickled into each task instead would not be shared).
+_FIXED: dict = {}
+
+
+def resolve_n_jobs(n_jobs: int) -> int:
+    """Normalize a config ``n_jobs`` (``< 1`` means "all but one core")."""
+    if n_jobs is None or n_jobs < 1:
+        return max(1, cpu_count() - 1)
+    return n_jobs
+
+
+def _init_worker(token: str, payload: Any) -> None:
+    _FIXED[token] = payload
+
+
+def _call_with_fixed(
+    worker_fn: Callable, token: str, args: Sequence[Any]
+) -> Any:
+    # Runs in the worker: resolve the once-shipped fixed payload and call through.
+    return worker_fn(_FIXED[token], *args)
+
+
+class GenerationRunner:
+    """Dispatch repeated identical worker calls, shipping ``fixed`` only once.
+
+    Parameters
+    ----------
+    n_jobs:
+        Number of parallel workers (``< 1`` means all-but-one core).
+    prefer:
+        ``"threads"`` — shared memory, no pickling; ``fixed`` is passed directly.
+        Best when the goal function releases the GIL (vectorized numpy) or on a
+        free-threaded interpreter.
+        ``"processes"`` — a dedicated ``loky`` process pool whose initializer
+        stashes ``fixed`` once per worker (``cloudpickle`` handles closures such
+        as the wrapped goal function). Best for CPU-bound pure-Python goal
+        functions.
+    fixed:
+        The run-constant payload handed to every worker call as its first
+        argument. Sent to each process worker exactly once.
+
+    Notes
+    -----
+    The processes backend owns a *dedicated* ``loky.ProcessPoolExecutor`` for
+    the run's lifetime rather than loky's process-global reusable executor.
+    Sharing that global singleton would collide with ``joblib.Parallel(prefer=
+    "processes")`` used elsewhere (e.g. gradient descent): joblib expects to
+    create and decorate the reusable executor itself, and finding a foreign one
+    raises ``AttributeError: ... has no attribute '_temp_folder_manager'``. A
+    dedicated pool keeps our once-shipped ``fixed`` payload isolated and is torn
+    down in :meth:`close`.
+    """
+
+    def __init__(self, n_jobs: int, prefer: str, fixed: Any):
+        self.n_jobs = resolve_n_jobs(n_jobs)
+        self.prefer = prefer
+        self._fixed = fixed
+        self._token: str | None = None
+        self._executor = None
+        self._parallel = None
+        if prefer == "processes":
+            self._token = uuid.uuid4().hex
+            # A dedicated pool (not loky's global reusable executor) so its
+            # initializer ships ``fixed`` once per worker for this run's token,
+            # without clobbering the reusable executor joblib.Parallel relies on.
+            self._executor = ProcessPoolExecutor(
+                max_workers=self.n_jobs,
+                initializer=_init_worker,
+                initargs=(self._token, fixed),
+            )
+        else:
+            self._parallel = joblib.Parallel(n_jobs=self.n_jobs, prefer="threads")
+
+    def run(
+        self, worker_fn: Callable, varying_args: Sequence[Any], count: int | None = None
+    ) -> list:
+        """Call ``worker_fn(fixed, *varying_args)`` ``count`` times in parallel.
+
+        ``count`` defaults to ``n_jobs`` (one task per worker per generation).
+        """
+        n = self.n_jobs if count is None else count
+        if self.prefer == "processes":
+            futures = [
+                self._executor.submit(
+                    _call_with_fixed, worker_fn, self._token, varying_args
+                )
+                for _ in range(n)
+            ]
+            return [f.result() for f in futures]
+        return self._parallel(
+            joblib.delayed(worker_fn)(self._fixed, *varying_args) for _ in range(n)
+        )
+
+    def close(self) -> None:
+        # Tear down our dedicated process pool so its workers (and the once-
+        # shipped fixed payload they hold) are released promptly. The threads
+        # backend holds no OS resources to free.
+        if self._executor is not None:
+            self._executor.shutdown(wait=True)
+            self._executor = None
+        self._parallel = None


### PR DESCRIPTION
## What

Implements report items **#2 (copy fixed data to workers once)** — the multiprocessing concern originally flagged — and **#11 (threads vs processes guidance)**. Follows the merged continuous-perf work (#67–#72).

Adds a shared `GenerationRunner` (`src/optimizers/core/parallel.py`) that splits worker arguments into:

- **fixed** — constant for the whole run: the `variables`, the wrapped goal function (which closes over the large read-only `args` dataset), and the hyper-parameters.
- **varying** — the bounded solution archive + rank CDF; small and cheap.

ACO/PSO/GA now build the `fixed` payload **once** at `solve()` start and dispatch only the small varying args each generation, instead of re-pickling everything to every worker every generation.

## How

- **`processes` backend:** a dedicated `loky.ProcessPoolExecutor` whose `initializer` stashes the fixed payload once per worker (keyed by an opaque token in a module global; `cloudpickle` handles the goal-fn closure). Per generation only the varying args are shipped.
- **`threads` backend:** `fixed` passed by reference (shared memory, no pickling).
- Uses a **dedicated** pool rather than loky's process-global reusable executor on purpose — sharing that singleton collides with `joblib.Parallel(prefer="processes")` used by gradient descent (`AttributeError: ... _temp_folder_manager`). The pool is spawned per `solve()` (~0.5–0.7 s, amortized) and torn down in `close()`.

## Evidence

Measured on the target hardware (3 workers, non-memmappable ~30 MB Python-object payload closed over by the goal fn). The old re-ship cost is *per generation*, so it scales with run length while ship-once stays flat:

| generations | old (re-ship/gen) | new (ship-once) | speedup |
|---:|---:|---:|---:|
| 12 | 2.24 s | 2.33 s | 0.96× |
| 30 | 5.38 s | 2.33 s | **2.3×** |
| 60 | 10.83 s | 2.38 s | **4.6×** |
| 100 | 18.12 s | 2.40 s | **7.5×** |

Crossover ~12 generations; the default `num_generations=50` is comfortably in the win zone.

**Nuance:** joblib already auto-memmaps large *numpy arrays* even inside closures, so for a purely-numpy fixed dataset the old path was already near-optimal. The large, generation-scaling win is for **non-array Python payloads** (dicts, lists, pandas/custom objects), which joblib must fully re-pickle every generation.

## Testing

- Full non-cluster suite green: **21 passed** (`pytest tests/ --ignore=tests/test_cluster.py`).
- End-to-end `processes`-backend run of ACO/PSO/GA with a goal fn closing over a 16 MB array — all converge; per-generation cost stays flat as the closure grows 128×, confirming the payload ships once.

🤖 Generated with [Claude Code](https://claude.com/claude-code)