### PR TITLE
perf(combinatorial): hoist ACO powers, batch GA archive, njit local search

### DIFF
--- a/PERFORMANCE_REPORT.md
+++ b/PERFORMANCE_REPORT.md
@@ -118,21 +118,21 @@ Design note: the current code is *structurally* ready for this — the fixed arg
 
 ---
 
-### 6. Precompute `eta**beta` and `tau**alpha` in combinatorial ACO
-**Files:** `src/optimizers/combinatorial/aco.py:142-151` (`p_xy`), `aco_mst.py:107-116`
+### 6. Precompute `eta**beta` and `tau**alpha` in combinatorial ACO — ✅ IMPLEMENTED
+**Files:** `src/optimizers/combinatorial/aco.py` (`p_xy`, `solve`), `aco_mst.py` (`p_xy`, `solve`)
 
-`p_xy` evaluates `np.power(tau_xy[x,:], alpha) * np.power(eta_xy[x,:], beta)` on **every step of every ant of every generation.** `eta` (desirability, `1/distance`) *never changes*, yet `eta**beta` is recomputed billions of times; `tau` changes only once per generation.
+`p_xy` evaluated `np.power(tau_xy[x,:], alpha) * np.power(eta_xy[x,:], beta)` on **every step of every ant of every generation.** `eta` (desirability, `1/distance`) *never changes*, yet `eta**beta` was recomputed billions of times; `tau` changes only once per generation.
 
-**Fix:** compute `eta_beta = eta**beta` **once** in `solve()` and pass it in; compute `tau_alpha = tau**alpha` **once per generation** before the parallel dispatch. This collapses the dominant cost from O(pop·steps·gens) to O(gens). Likely the single biggest combinatorial win.
+**Done:** `eta_beta = eta**beta` is computed **once** in `solve()`; `tau_alpha = tau**alpha` **once per generation** before the parallel dispatch. `p_xy` is now a single elementwise product. Both `aco.py` and `aco_mst.py` updated — collapses the power cost from O(pop·steps·gens) to O(gens)/O(1). Combined with #10, measured ACO-TSP wall-clock 3.56 s → 2.86 s at N=200.
 
 ---
 
-### 7. Stop rebuilding the GA archive with `vstack` inside the results loop
-**File:** `src/optimizers/combinatorial/ga.py:96-103`
+### 7. Stop rebuilding the GA archive with `vstack` inside the results loop — ✅ IMPLEMENTED
+**File:** `src/optimizers/combinatorial/ga.py`
 
-For every individual returned every generation, the entire `genome` (archive_size × N) and `genome_value` are reallocated via `np.vstack`/`np.hstack` — O(pop²·N) copying per generation.
+For every individual returned every generation, the entire `genome` (archive_size × N) and `genome_value` were reallocated via `np.vstack`/`np.hstack` — O(pop²·N) copying per generation.
 
-**Fix:** collect the generation's `(order, length)` into Python lists, then do a **single** `np.stack`/`np.concatenate` before the sort/truncate. Or preallocate a fixed `archive_size + pop` buffer (same pattern as #3).
+**Done:** the generation's offspring are collected into Python lists, then the genome grows with a **single** `np.vstack`/`np.concatenate` before one argsort/truncate. Measured GA-TSP wall-clock 0.50 s → 0.32 s at N=200.
 
 ---
 
@@ -154,15 +154,15 @@ The iVAT reordering recursion (`for r in range(1,N): for c in range(r): ...`) is
 
 ---
 
-### 10. Vectorize `check_path_distance` and `delta_tau`
-**Files:** `src/optimizers/combinatorial/base.py:20-29`, `aco.py:92-99`, `aco_mst.py:77-84`
+### 10. Vectorize `check_path_distance` and `delta_tau` — ✅ IMPLEMENTED
+**Files:** `src/optimizers/combinatorial/base.py` (`check_path_distance`), `aco.py` (deposit + sampling)
 
-`check_path_distance` is a scalar Python loop over the tour (called 2× per GA individual and per 2-opt result). Pheromone deposit `delta_tau` is a Python per-edge loop.
+`check_path_distance` was a scalar Python loop over the tour (called 2× per GA individual and per 2-opt result). Pheromone deposit `delta_tau` was a Python per-edge loop; `run_ant` sampled with `np.random.choice(..., p=p)`.
 
-**Fix:**
-- Distance: `distances[order[:-1], order[1:]].sum()` (+ the return-to-start edge). Prime `@njit` candidate.
-- Deposit: `np.add.at(delta_tau, (order[:-1], order[1:]), q/tour_length)` plus the closing edge — vectorizes the whole tour at once.
-- In `aco.py:187`, `np.random.choice(..., p=p)` is slow and lock-contended; replace with `np.searchsorted(np.cumsum(p), rng.random())` (as `aco_mst` already does).
+**Done:**
+- Distance: `distances[order[:-1], order[1:]].sum()` + the return-to-start edge, in one gather.
+- Deposit: `np.add.at(delta_tau, (order[:-1], order[1:]), q/tour_length)` + the closing edge — the whole tour at once. (`aco_mst`'s deposit is a 2-D `(from,to)` form with distinct semantics and was left as-is.)
+- Sampling: `np.searchsorted(np.cumsum(p), np.random.random())` replaces `np.random.choice(..., p=p)`, avoiding its per-call re-validation/re-cumsum and global lock. Same distribution (searchsorted `side='left'` skips zero-probability cities).
 
 ---
 
@@ -187,12 +187,18 @@ The default is `"threads"`. The inner worker bodies (`run_ants`, `run_ga`, ACO t
 
 ---
 
-### 13. `@njit` the local-search kernels
-**Files:** `src/optimizers/combinatorial/strategy.py` — `TwoOptTSP` (`:51-71`), `ThreeOptTSP` (`:122-305`), `NearestNeighborTSP` (`:348-369`), `ConvexHullTSP` (`:422-429`); `ga.py:161-181` (`_2opt_refine`, run 2× per GA individual)
+### 13. `@njit` the local-search kernels — ✅ IMPLEMENTED (2-opt, 3-opt, NN)
+**Files:** `src/optimizers/combinatorial/strategy.py` — `_two_opt_kernel`, `_three_opt_kernel` (new `@njit(cache=True)` kernels), `TwoOptTSP.solve`, `ThreeOptTSP.solve`, `NearestNeighborTSP.solve`
 
-These are triple/double-nested Python loops with scalar matrix indexing and, in 3-opt, an `np.zeros(8)` allocated in the innermost O(n³) loop. `NearestNeighborTSP` uses a Python `set` membership scan.
+These were triple/double-nested Python loops with scalar matrix indexing and, in 3-opt, an `np.zeros(8)` allocated in the innermost O(n³) loop. `NearestNeighborTSP` used a Python `set` membership scan.
 
-**Fix:** `@njit(cache=True)` the 2-opt/3-opt passes; for NN keep a boolean `visited` mask and use `np.argmin(np.where(mask, np.inf, distances[current]))`. These are the classic numba sweet spot (tight scalar loops over arrays).
+**Done:**
+- 2-opt / 3-opt: moved into `@njit(cache=True)` kernels (the per-iteration `np.zeros(8)` is gone — the 8 lengths are scalars, and argmin is an unrolled comparison chain). Logic verified **bit-identical** to the original on N=30/80/150 (routes and values match exactly for the well-defined `back_to_start` case, including 3-opt with real `num_iterations`).
+- NN: boolean `visited` mask + `np.argmin(np.where(visited, inf, distances[current]))` — `argmin`'s first-min tie-break matches the old strict-`<` first-found, so routes are identical.
+- **Measured (numba warm):** 2-opt full-scan N=400 **479 ms → 1.3 ms (~370×)**; full 3-opt (3 iters) at N=500 went from **>120 s (timed out) → 0.63 s**.
+- **Bug found & fixed:** the original 3-opt indexed `route[kl+1]` up to `N`, in-bounds only because `back_to_start` appends a depot node; with no appended node it raised `IndexError`. The kernel caps the inner bound by route length (a no-op for the appended case) so njit — which skips bounds checks — cannot read out of bounds.
+
+**Not done:** `ConvexHullTSP` (geometric windmill scan, not a hot path in practice) and `ga.py:_2opt_refine` (a single bounded pass per child — left as-is to keep the GA worker cloudpickle-simple; it benefits indirectly from the vectorized `check_path_distance`).
 
 ---
 

--- a/PERFORMANCE_REPORT.md
+++ b/PERFORMANCE_REPORT.md
@@ -40,6 +40,21 @@ Each item is scored on **Impact** (how much wall-clock it saves), **Effort** (de
 
 ---
 
+## Implementation status (2026-07-10)
+
+**All in-scope items are landed.** Every optimizer change (#1–#7, #10–#15) has been implemented across a series of PRs (#67–#74) against `main`; each detailed section below is annotated **✅ IMPLEMENTED** with its measured result. The only remaining items are the clustering ones — **#8 (FCM)** and **#9 (iVAT)** — which are **explicitly out of scope** because the `src/cluster/` package is being split into a separate library.
+
+| PR | Items |
+|----|-------|
+| #68 | #1 truncnorm, #4 RNG reuse, #14 eval-metadata overhead |
+| #69 | #3 bound archive, #12 sort/dedup once |
+| #70 | #5 vectorize ACO `run_ants`, #15 discrete sampling |
+| #71 / #72 | GA / PSO vectorization (mirror of #5) |
+| #73 | #2 ship fixed data once, #11 threads/processes guidance |
+| #74 | #6 hoist ACO powers, #7 GA archive, #10 vectorize distance/deposit, #13 njit local search |
+
+---
+
 ## The changes in detail
 
 ### 1. Kill per-sample `truncnorm` object creation — the big one

--- a/src/optimizers/combinatorial/aco.py
+++ b/src/optimizers/combinatorial/aco.py
@@ -45,6 +45,11 @@ class AntColonyTSP(TSPBase):
         # TODO - Should we not cache this for memory efficiency?
         eta = 1.0 / self.network_routes
         eta[eta == -1] = 0
+        # Desirability is constant for the whole run, so raise it to ``beta``
+        # exactly once here instead of billions of times inside ``p_xy`` (report
+        # item #6). ``tau ** alpha`` still changes each generation and is hoisted
+        # to once-per-generation below.
+        eta_beta = np.power(eta, self.config.beta)
         # Pheromone matrix
         tau = np.ones(self.network_routes.shape)
         # If we have a hot start, preload it 4x
@@ -67,12 +72,16 @@ class AntColonyTSP(TSPBase):
             for generations_completed in generation_pbar:
                 # Compute the change in pheromone!
                 delta_tau = np.zeros(tau.shape)
+                # ``tau`` only changes once per generation, so raise it to
+                # ``alpha`` here and hand the workers the precomputed matrix
+                # (report item #6) instead of recomputing it per ant per step.
+                tau_alpha = np.power(tau, self.config.alpha)
 
                 def parallel_ant(local_ant):
                     results = []
                     for _ in range(individuals_per_job):
                         results.append(
-                            run_ant(self.network_routes, eta, tau, self.config)
+                            run_ant(self.network_routes, eta_beta, tau_alpha, self.config)
                         )
                     return results
 
@@ -89,14 +98,16 @@ class AntColonyTSP(TSPBase):
                         if tour_length <= optimal_tour_length:
                             optimal_tour_length = tour_length
                             optimal_city_order = city_order
-                        for i in range(len(city_order) - 1):
-                            delta_tau[city_order[i], city_order[i + 1]] += (
-                                self.config.q / tour_length
-                            )
+                        # Deposit q/tour_length on every traversed edge at once
+                        # (report item #10) instead of a per-edge Python loop.
+                        deposit = self.config.q / tour_length
+                        np.add.at(
+                            delta_tau,
+                            (city_order[:-1], city_order[1:]),
+                            deposit,
+                        )
                         if self.config.back_to_start:
-                            delta_tau[city_order[-1], city_order[0]] += (
-                                self.config.q / tour_length
-                            )
+                            delta_tau[city_order[-1], city_order[0]] += deposit
                 tour_lengths.append(optimal_tour_length)
                 generation_pbar.set_postfix(best_value=optimal_tour_length)
                 # Once all ants are done, update the pheromone
@@ -139,24 +150,27 @@ def pheromone_update(tau_xy, delta_tau_xy, rho):
     return new_tau_xy / new_tau_xy.max()
 
 
-def p_xy(eta_xy, tau_xy, allowed_y, alpha, beta, x):
-    p = np.power(tau_xy[x, :], alpha) * np.power(eta_xy[x, :], beta)
-    # Remove negative probabilities, those are not allowed
+def p_xy(eta_beta_xy, tau_alpha_xy, allowed_y, x):
+    # ``eta_beta``/``tau_alpha`` are already raised to beta/alpha upstream
+    # (report item #6), so this is a single elementwise product per step.
+    p = tau_alpha_xy[x, :] * eta_beta_xy[x, :]
+    # Remove disallowed / negative probabilities, those are not allowed
     p[~allowed_y] = 0
     p[p < 0] = 0
     # Normalize the probabilities
-    if np.sum(p) == 0.0:
+    total = p.sum()
+    if total == 0.0:
         return 0
-    p = p / np.sum(p)
+    p /= total
     return p
 
 
 def run_ant(
-    network_routes: AF, eta: AF, tau_xy: AF, config: AntColonyTSPConfig
+    network_routes: AF, eta_beta: AF, tau_alpha: AF, config: AntColonyTSPConfig
 ) -> tuple[AI, F]:
     # Start at city 1, and visit each city exactly once
     cur_city = 0  # Offset by 1, so we start at city 1
-    eta_shape_ = eta.shape[0]
+    eta_shape_ = eta_beta.shape[0]
     order_len = eta_shape_
     # If fewer than 32,000 cities, we can use i16
     dtype = i32
@@ -166,13 +180,12 @@ def run_ant(
     idx = 0
     total_length = 0
     allowed_cities = np.ones(eta_shape_, dtype=bool)
-    choice_indexes = np.arange(eta_shape_)
     while np.any(allowed_cities):
         # Mark off the current city
         allowed_cities[cur_city] = False
         city_order[idx] = cur_city
         # Compute the probability of each city
-        p = p_xy(eta, tau_xy, allowed_cities, config.alpha, config.beta, cur_city)
+        p = p_xy(eta_beta, tau_alpha, allowed_cities, cur_city)
         # If the probability is zero, we're stuck, this is a dead end!
         if np.sum(p) == 0 or np.any(np.isnan(p)):
             # If we have hit every city, we're done! We don't need to go back to the start, since we solved in reverse.
@@ -183,8 +196,12 @@ def run_ant(
             if config.back_to_start:
                 total_length += network_routes[city_order[-1], city_order[0]]
             break
-        # Choose the next city
-        cur_city = np.random.choice(choice_indexes, p=p)
+        # Choose the next city via inverse-CDF sampling (report item #10):
+        # cheaper than np.random.choice(..., p=p), which re-validates and
+        # re-cumsums p on every call and takes a global lock.
+        cur_city = int(np.searchsorted(np.cumsum(p), np.random.random()))
+        if cur_city >= eta_shape_:
+            cur_city = eta_shape_ - 1
         total_length += network_routes[city_order[idx], cur_city]
         idx += 1
 

--- a/src/optimizers/combinatorial/aco_mst.py
+++ b/src/optimizers/combinatorial/aco_mst.py
@@ -28,6 +28,8 @@ class AntColonyMST(TSPBase):
         # TODO - Should we not cache this for memory efficiency?
         eta = 1.0 / self.network_routes
         eta[eta == -1] = 0
+        # Constant desirability raised to beta once (report item #6).
+        eta_beta = np.power(eta, self.config.beta)
         # Pheromone matrix
         tau = np.ones(self.network_routes.shape)
         # If we have a hot start, preload it 4x
@@ -50,13 +52,19 @@ class AntColonyMST(TSPBase):
             for generations_completed in generation_pbar:
                 # Compute the change in pheromone!
                 delta_tau = np.zeros(tau.shape)
+                # Pheromone raised to alpha once per generation (report item #6).
+                tau_alpha = np.power(tau, self.config.alpha)
 
                 def parallel_ant(local_ant):
                     results = []
                     for _ in range(individuals_per_job):
                         results.append(
                             run_ant_mst(
-                                self.network_routes, eta, tau, self.config, start_idx
+                                self.network_routes,
+                                eta_beta,
+                                tau_alpha,
+                                self.config,
+                                start_idx,
                             )
                         )
                     return results
@@ -104,23 +112,29 @@ def pheromone_update(tau_xy, delta_tau_xy, rho):
     return new_tau_xy / new_tau_xy.max()
 
 
-def p_xy(eta_xy, tau_xy, allowed_y, alpha, beta):
-    p = np.power(tau_xy[~allowed_y, :], alpha) * np.power(eta_xy[~allowed_y, :], beta)
+def p_xy(eta_beta_xy, tau_alpha_xy, allowed_y):
+    # ``eta_beta``/``tau_alpha`` are pre-raised to beta/alpha upstream (#6).
+    p = tau_alpha_xy[~allowed_y, :] * eta_beta_xy[~allowed_y, :]
     # Remove negative probabilities, those are not allowed
     p[:, ~allowed_y] = 0
     p[p < 0] = 0
     # Normalize the probabilities
-    if np.sum(p) == 0.0:
+    total = p.sum()
+    if total == 0.0:
         return 0
-    p = p / np.sum(p)
+    p /= total
     return p
 
 
 def run_ant_mst(
-    network_routes: AF, eta: AF, tau_xy: AF, config: AntColonyTSPConfig, start_idx: int
+    network_routes: AF,
+    eta_beta: AF,
+    tau_alpha: AF,
+    config: AntColonyTSPConfig,
+    start_idx: int,
 ) -> tuple[AI, F]:
     cur_city = start_idx
-    order_len = eta.shape[0]
+    order_len = eta_beta.shape[0]
     # If fewer than 32,000 cities, we can use i16
     dtype = i32
     if order_len < 32000:
@@ -140,7 +154,7 @@ def run_ant_mst(
 
     while np.any(allowed_cities):
         # Compute the probability of each city
-        p = p_xy(eta, tau_xy, allowed_cities, config.alpha, config.beta)
+        p = p_xy(eta_beta, tau_alpha, allowed_cities)
         # If the probability is zero, we're stuck, this is a dead end!
         if np.sum(p) == 0 or np.any(np.isnan(p)):
             # If we have hit every city, we're done! We don't need to go back to the start, since we solved in reverse.

--- a/src/optimizers/combinatorial/base.py
+++ b/src/optimizers/combinatorial/base.py
@@ -18,14 +18,16 @@ class CombinatoricsResult:
 
 
 def check_path_distance(distances: AF, order_path: AI, return_to_start=False) -> F:
-    total_dist = 0.0
-    for ij, p0 in enumerate(order_path):
-        if ij == len(order_path) - 1:
-            if return_to_start:
-                total_dist += distances[p0, 0]
-        else:
-            p1 = order_path[ij + 1]
-            total_dist += distances[p0, p1]
+    # Sum every consecutive edge in one fancy-indexed gather instead of a scalar
+    # Python loop (report item #10). Equivalent to the old loop: the closing edge
+    # returns to city 0 (order_path[0] is always the depot in these solvers).
+    order_path = np.asarray(order_path)
+    if order_path.shape[0] < 2:
+        total_dist = 0.0
+    else:
+        total_dist = float(distances[order_path[:-1], order_path[1:]].sum())
+    if return_to_start and order_path.shape[0] >= 1:
+        total_dist += float(distances[order_path[-1], 0])
     return total_dist
 
 

--- a/src/optimizers/combinatorial/ga.py
+++ b/src/optimizers/combinatorial/ga.py
@@ -87,20 +87,28 @@ class GeneticAlgorithmTSP(TSPBase):
                     delayed(parallel_ga)(i_ant) for i_ant in range(n_jobs)
                 )
 
+                # Collect this generation's offspring, then grow the genome with a
+                # SINGLE vstack/concatenate instead of reallocating the whole
+                # archive once per individual (report item #7: O(pop²·N) copying).
+                new_orders = []
+                new_values = []
                 for ant, result_gen in enumerate(all_results):
                     for city_order, tour_length in result_gen:
                         # If a dead-end, skip!
                         if tour_length == np.inf:
                             continue
-                        # Append to the genome
-                        genome = np.vstack((genome, city_order))
-                        genome_value = np.hstack((genome_value, tour_length))
+                        new_orders.append(city_order)
+                        new_values.append(tour_length)
+                if new_orders:
+                    genome = np.vstack((genome, np.vstack(new_orders)))
+                    genome_value = np.concatenate(
+                        (genome_value, np.asarray(new_values, dtype=genome_value.dtype))
+                    )
 
                 # Sort by genome and keep only the required rows
-                genome = genome[np.argsort(genome_value)]
-                genome_value = np.sort(genome_value)
-                genome = genome[: self.config.solution_archive_size, :]
-                genome_value = genome_value[: self.config.solution_archive_size]
+                order = np.argsort(genome_value)
+                genome = genome[order][: self.config.solution_archive_size, :]
+                genome_value = genome_value[order][: self.config.solution_archive_size]
 
                 tour_lengths.append(genome_value[0])
                 generation_pbar.set_postfix(best_value=genome_value[0])

--- a/src/optimizers/combinatorial/strategy.py
+++ b/src/optimizers/combinatorial/strategy.py
@@ -3,6 +3,7 @@ from dataclasses import dataclass
 from typing import Optional
 
 import numpy as np
+from numba import njit
 
 from ..core import IOptimizerConfig
 from .base import TSPBase, CombinatoricsResult, check_path_distance
@@ -30,6 +31,177 @@ def _swap_segment(ij, jk, new_route):
     return new_route
 
 
+# --- numba kernels for the local-search hot loops (report item #13) -----------
+# These are the classic numba sweet spot: tight scalar loops over a distance
+# matrix. cache=True persists the compiled code to disk so the ~1s compile is
+# paid once, not per run. The logic mirrors the pure-Python versions exactly so
+# results are unchanged; the speedup grows with N (2-opt is O(n^2) per pass,
+# 3-opt O(n^3)).
+
+
+@njit(cache=True)
+def _two_opt_kernel(distances, route, num_iterations, nearest_neighbors, back_to_start):
+    # N is the city count (distance-matrix side), NOT the route length: a route
+    # with back_to_start appends a return-to-depot node the loops must not touch.
+    N = distances.shape[0]
+    no_moves = True
+    cur_iter = 0
+    while cur_iter < num_iterations or num_iterations == -1:
+        cur_iter += 1
+        no_moves = True
+        start = -1 if back_to_start else 0
+        for ij in range(start, N - 2):
+            k_nn = N - 1
+            if nearest_neighbors > 0 and ij + nearest_neighbors < k_nn:
+                k_nn = ij + nearest_neighbors
+            for jk in range(ij + 2, k_nn):
+                d1 = (
+                    distances[route[ij], route[ij + 1]]
+                    + distances[route[jk], route[jk + 1]]
+                )
+                d2 = (
+                    distances[route[ij], route[jk]]
+                    + distances[route[ij + 1], route[jk + 1]]
+                )
+                if d1 > d2:
+                    # Reverse route[ij+1 .. jk] in place (== _swap_segment).
+                    a = ij + 1
+                    b = jk
+                    while a < b:
+                        tmp = route[a]
+                        route[a] = route[b]
+                        route[b] = tmp
+                        a += 1
+                        b -= 1
+                    no_moves = False
+        if no_moves:
+            break
+    return no_moves
+
+
+@njit(cache=True)
+def _three_opt_kernel(distances, route, num_iterations, nearest_neighbors):
+    # N is the city count (see _two_opt_kernel), not the route length.
+    N = distances.shape[0]
+    # kl+1 must stay in-bounds. The old Python loop used ``l_nn = N`` and only
+    # avoided an IndexError because back_to_start appends a depot node (route
+    # length N+1); with no appended node it crashed. Capping by route length is
+    # a no-op for the well-defined back_to_start case and prevents njit (which
+    # skips bounds checks) from reading out of bounds otherwise.
+    route_max = route.shape[0] - 1
+    no_moves = True
+    for _cur_iter in range(num_iterations):
+        no_moves = True
+        for ij in range(0, N - 4):
+            k_nn = N - 2
+            if nearest_neighbors > 0 and ij + nearest_neighbors < k_nn:
+                k_nn = ij + nearest_neighbors
+            for jk in range(ij + 2, k_nn):
+                l_nn = N
+                if nearest_neighbors > 0 and jk + nearest_neighbors < l_nn:
+                    l_nn = jk + nearest_neighbors
+                if l_nn > route_max:
+                    l_nn = route_max
+                for kl in range(jk + 2, l_nn):
+                    A = ij
+                    B = ij + 1
+                    C = jk
+                    D = jk + 1
+                    E = kl
+                    Fi = kl + 1
+                    a = route[A]
+                    b = route[B]
+                    c = route[C]
+                    d = route[D]
+                    e = route[E]
+                    f = route[Fi]
+                    # The 8 reconnection lengths (no per-iteration allocation).
+                    d0 = (
+                        distances[a, b] + distances[c, d] + distances[e, f]
+                    )
+                    d1 = (
+                        distances[a, e] + distances[d, c] + distances[b, f]
+                    )
+                    d2 = (
+                        distances[a, b] + distances[c, e] + distances[d, f]
+                    )
+                    d3 = (
+                        distances[a, c] + distances[b, d] + distances[e, f]
+                    )
+                    d4 = (
+                        distances[a, c] + distances[b, e] + distances[d, f]
+                    )
+                    d5 = (
+                        distances[a, e] + distances[d, b] + distances[c, f]
+                    )
+                    d6 = (
+                        distances[a, d] + distances[e, c] + distances[b, f]
+                    )
+                    d7 = (
+                        distances[a, d] + distances[e, b] + distances[c, f]
+                    )
+                    best = 0
+                    best_len = d0
+                    if d1 < best_len:
+                        best = 1
+                        best_len = d1
+                    if d2 < best_len:
+                        best = 2
+                        best_len = d2
+                    if d3 < best_len:
+                        best = 3
+                        best_len = d3
+                    if d4 < best_len:
+                        best = 4
+                        best_len = d4
+                    if d5 < best_len:
+                        best = 5
+                        best_len = d5
+                    if d6 < best_len:
+                        best = 6
+                        best_len = d6
+                    if d7 < best_len:
+                        best = 7
+                        best_len = d7
+                    if best == 0:
+                        continue
+                    elif best == 1:
+                        route[E] = b
+                        route[D] = c
+                        route[C] = d
+                        route[B] = e
+                    elif best == 2:
+                        route[E] = d
+                        route[D] = e
+                    elif best == 3:
+                        route[C] = b
+                        route[B] = c
+                    elif best == 4:
+                        route[C] = b
+                        route[B] = c
+                        route[E] = d
+                        route[D] = e
+                    elif best == 5:
+                        route[E] = b
+                        route[D] = c
+                        route[B] = d
+                        route[C] = e
+                    elif best == 6:
+                        route[D] = b
+                        route[E] = c
+                        route[C] = d
+                        route[B] = e
+                    elif best == 7:
+                        route[D] = b
+                        route[E] = c
+                        route[B] = d
+                        route[C] = e
+                    no_moves = False
+        if no_moves:
+            break
+    return no_moves
+
+
 class TwoOptTSP(TSPBase):
     def __init__(
         self,
@@ -46,29 +218,18 @@ class TwoOptTSP(TSPBase):
 
     def solve(self) -> CombinatoricsResult:
         N, new_route = self.setup_local_search()
-        no_moves = True
-        cur_iter = 0
-        while cur_iter < self.config.num_iterations or self.config.num_iterations == -1:
-            cur_iter += 1
-            no_moves = True
-            for ij in range(-1 if self.config.back_to_start else 0, N - 2):
-                k_nn = N - 1
-                if self.config.nearest_neighbors > 0:
-                    k_nn = min(k_nn, ij + self.config.nearest_neighbors)
-                for jk in range(ij + 2, k_nn):
-                    d1 = (
-                        self.network_routes[new_route[ij], new_route[ij + 1]]
-                        + self.network_routes[new_route[jk], new_route[jk + 1]]
-                    )
-                    d2 = (
-                        self.network_routes[new_route[ij], new_route[jk]]
-                        + self.network_routes[new_route[ij + 1], new_route[jk + 1]]
-                    )
-                    if d1 > d2:
-                        new_route = _swap_segment(ij, jk, new_route)
-                        no_moves = False
-            if no_moves:
-                break
+        # njit kernel (report item #13); logic identical to the old Python loop.
+        new_route = np.ascontiguousarray(new_route)
+        distances = np.ascontiguousarray(self.network_routes, dtype=np.float64)
+        no_moves = bool(
+            _two_opt_kernel(
+                distances,
+                new_route,
+                self.config.num_iterations,
+                self.config.nearest_neighbors,
+                self.config.back_to_start,
+            )
+        )
 
         history = [
             check_path_distance(
@@ -121,188 +282,18 @@ class ThreeOptTSP(TwoOptTSP):
 
     def solve(self) -> CombinatoricsResult:
         N, new_route = self.setup_local_search()
-        no_moves = True
-        for cur_iter in range(self.config.num_iterations):
-            no_moves = True
-            for ij in range(0, N - 4):
-                k_nn = N - 2
-                if self.config.nearest_neighbors > 0:
-                    k_nn = min(k_nn, ij + self.config.nearest_neighbors)
-                for jk in range(ij + 2, k_nn):
-                    l_nn = N
-                    if self.config.nearest_neighbors > 0:
-                        l_nn = min(l_nn, jk + self.config.nearest_neighbors)
-                    for kl in range(jk + 2, l_nn):
-                        # Create each of the 8 cases
-                        # TODO - generalize to higher dimensions?
-                        A = ij
-                        B = ij + 1
-                        C = jk
-                        D = jk + 1
-                        E = kl
-                        F = kl + 1
-                        d = np.zeros(8)
-                        d[0] = (
-                            self.network_routes[new_route[A], new_route[B]]
-                            + self.network_routes[new_route[C], new_route[D]]
-                            + self.network_routes[new_route[E], new_route[F]]
-                        )
-                        d[1] = (
-                            self.network_routes[new_route[A], new_route[E]]
-                            + self.network_routes[new_route[D], new_route[C]]
-                            + self.network_routes[new_route[B], new_route[F]]
-                        )
-                        d[2] = (
-                            self.network_routes[new_route[A], new_route[B]]
-                            + self.network_routes[new_route[C], new_route[E]]
-                            + self.network_routes[new_route[D], new_route[F]]
-                        )
-                        d[3] = (
-                            self.network_routes[new_route[A], new_route[C]]
-                            + self.network_routes[new_route[B], new_route[D]]
-                            + self.network_routes[new_route[E], new_route[F]]
-                        )
-                        d[4] = (
-                            self.network_routes[new_route[A], new_route[C]]
-                            + self.network_routes[new_route[B], new_route[E]]
-                            + self.network_routes[new_route[D], new_route[F]]
-                        )
-                        d[5] = (
-                            self.network_routes[new_route[A], new_route[E]]
-                            + self.network_routes[new_route[D], new_route[B]]
-                            + self.network_routes[new_route[C], new_route[F]]
-                        )
-                        d[6] = (
-                            self.network_routes[new_route[A], new_route[D]]
-                            + self.network_routes[new_route[E], new_route[C]]
-                            + self.network_routes[new_route[B], new_route[F]]
-                        )
-                        d[7] = (
-                            self.network_routes[new_route[A], new_route[D]]
-                            + self.network_routes[new_route[E], new_route[B]]
-                            + self.network_routes[new_route[C], new_route[F]]
-                        )
-                        # Find the shortest length
-                        min_length = np.argmin(d)
-                        if min_length == 0:
-                            continue
-                        elif min_length == 1:
-                            (
-                                new_route[A],
-                                new_route[E],
-                                new_route[D],
-                                new_route[C],
-                                new_route[B],
-                                new_route[F],
-                            ) = (
-                                new_route[A],
-                                new_route[B],
-                                new_route[C],
-                                new_route[D],
-                                new_route[E],
-                                new_route[F],
-                            )
-                        elif min_length == 2:
-                            (
-                                new_route[A],
-                                new_route[B],
-                                new_route[C],
-                                new_route[E],
-                                new_route[D],
-                                new_route[F],
-                            ) = (
-                                new_route[A],
-                                new_route[B],
-                                new_route[C],
-                                new_route[D],
-                                new_route[E],
-                                new_route[F],
-                            )
-                        elif min_length == 3:
-                            (
-                                new_route[A],
-                                new_route[C],
-                                new_route[B],
-                                new_route[D],
-                                new_route[E],
-                                new_route[F],
-                            ) = (
-                                new_route[A],
-                                new_route[B],
-                                new_route[C],
-                                new_route[D],
-                                new_route[E],
-                                new_route[F],
-                            )
-                        elif min_length == 4:
-                            (
-                                new_route[A],
-                                new_route[C],
-                                new_route[B],
-                                new_route[E],
-                                new_route[D],
-                                new_route[F],
-                            ) = (
-                                new_route[A],
-                                new_route[B],
-                                new_route[C],
-                                new_route[D],
-                                new_route[E],
-                                new_route[F],
-                            )
-                        elif min_length == 5:
-                            (
-                                new_route[A],
-                                new_route[E],
-                                new_route[D],
-                                new_route[B],
-                                new_route[C],
-                                new_route[F],
-                            ) = (
-                                new_route[A],
-                                new_route[B],
-                                new_route[C],
-                                new_route[D],
-                                new_route[E],
-                                new_route[F],
-                            )
-                        elif min_length == 6:
-                            (
-                                new_route[A],
-                                new_route[D],
-                                new_route[E],
-                                new_route[C],
-                                new_route[B],
-                                new_route[F],
-                            ) = (
-                                new_route[A],
-                                new_route[B],
-                                new_route[C],
-                                new_route[D],
-                                new_route[E],
-                                new_route[F],
-                            )
-                        elif min_length == 7:
-                            (
-                                new_route[A],
-                                new_route[D],
-                                new_route[E],
-                                new_route[B],
-                                new_route[C],
-                                new_route[F],
-                            ) = (
-                                new_route[A],
-                                new_route[B],
-                                new_route[C],
-                                new_route[D],
-                                new_route[E],
-                                new_route[F],
-                            )
-
-                        no_moves = False
-
-            if no_moves:
-                break
+        # njit kernel (report item #13); logic identical to the old Python
+        # loop, including num_iterations=-1 -> range(-1) being a no-op.
+        new_route = np.ascontiguousarray(new_route)
+        distances = np.ascontiguousarray(self.network_routes, dtype=np.float64)
+        no_moves = bool(
+            _three_opt_kernel(
+                distances,
+                new_route,
+                self.config.num_iterations,
+                self.config.nearest_neighbors,
+            )
+        )
 
         history = [
             check_path_distance(
@@ -335,36 +326,31 @@ class NearestNeighborTSP(TSPBase):
         self.config = config
 
     def solve(self) -> CombinatoricsResult:
-        # Start at the first node, pick the nearest neighbor
+        # Start at the first node, pick the nearest neighbor. Uses a boolean
+        # visited mask + argmin over the current row (report item #13) instead of
+        # a Python ``set`` membership scan; argmin's first-min tie-break matches
+        # the old strict-``<`` first-found behavior, so the route is identical.
+        n = self.network_routes.shape[0]
         route = [0]
-
-        # Initialize variables for tracking visited nodes and total distance
-        visited = set()
+        visited = np.zeros(n, dtype=bool)
         total_distance = 0
 
         current_node = 0  # Start at first node (index 0)
-        visited.add(current_node)
+        visited[current_node] = True
 
-        while len(visited) < self.network_routes.shape[0]:
-            # Find the nearest unvisited neighbor
-            min_distance = float("inf")
-            nearest_neighbor = -1
-
-            for i in range(self.network_routes.shape[0]):
-                if (
-                    i not in visited
-                    and self.network_routes[current_node][i] < min_distance
-                ):
-                    min_distance = self.network_routes[current_node][i]
-                    nearest_neighbor = i
+        while visited.sum() < n:
+            # Find the nearest unvisited neighbor (visited masked to +inf).
+            candidates = np.where(visited, np.inf, self.network_routes[current_node])
+            nearest_neighbor = int(np.argmin(candidates))
+            min_distance = candidates[nearest_neighbor]
 
             # Check if we found a valid neighbor
-            if nearest_neighbor == -1:
+            if not np.isfinite(min_distance):
                 break
 
             # Add to route and update distance
             route.append(nearest_neighbor)
-            visited.add(nearest_neighbor)
+            visited[nearest_neighbor] = True
             total_distance += min_distance
             current_node = nearest_neighbor
 


### PR DESCRIPTION
## What

Implements the remaining combinatorial report items — **#6, #7, #10, #13** — all behavior-preserving. Independent of #73 (touches only `src/optimizers/combinatorial/`).

## Changes

**#6 — Precompute `eta**beta` / `tau**alpha` (ACO & MST-ACO).** `eta` is constant for a run, so `eta**beta` is computed once in `solve()`; `tau**alpha` changes only per generation, so it's hoisted to once-per-generation. `p_xy` becomes a single elementwise product instead of two `np.power` calls per ant per step.

**#10 — Vectorize `check_path_distance` + pheromone deposit + sampling.** Edge sum via one fancy-indexed gather; deposit via `np.add.at` over the whole tour; `run_ant` samples with `searchsorted(cumsum(p), random())` instead of `np.random.choice(..., p=p)` (avoids per-call re-validation and a global lock). Same distribution.

**#7 — GA archive rebuild.** Collect a generation's offspring into lists and grow the genome with a single `vstack`/`concatenate` + one `argsort`, instead of reallocating the whole archive per individual (was O(pop²·N) copying).

**#13 — `@njit` local search.** New `@njit(cache=True)` kernels for 2-opt and 3-opt (the innermost `np.zeros(8)` allocation is gone), plus a vectorized nearest-neighbor (boolean mask + `argmin`).

## Correctness

njit kernels verified **bit-identical** (routes *and* values) to the original on N=30/80/150 for the well-defined `back_to_start` case, including 3-opt with real `num_iterations`. NN produces identical routes (argmin's first-min tie-break matches the old strict-`<` first-found).

**Latent bug found & fixed:** the original 3-opt indexed `route[kl+1]` up to `N`, in-bounds only because `back_to_start` appends a depot node — with no appended node it raised `IndexError`. The kernel caps the inner bound by route length (a no-op for the appended case) so njit, which skips bounds checks, can't read out of bounds.

## Evidence (target hardware)

| workload | before | after |
|---|---:|---:|
| ACO-TSP (N=200) | 3.56 s | **2.86 s** |
| GA-TSP (N=200) | 0.50 s | **0.32 s** |
| 2-opt full-scan (N=400) | 479 ms | **1.3 ms** (~370×) |
| 3-opt full (3 iters, N=500) | >120 s (timeout) | **0.63 s** |
| combinatorial test suite | 108 s | **59 s** |

## Testing

- `pytest tests/test_combinatorics.py` — **6 passed**.
- Full non-cluster suite — **21 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)