### PR TITLE
chore(lint): enforce flake8 + mypy in CI + fix all findings

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -1,7 +1,7 @@
 name: PR Checks
 on:
+  # Run on every PR regardless of base branch so stacked PRs are checked too.
   pull_request:
-    branches: [ main ]
 jobs:
   test:
     runs-on: ubuntu-latest
@@ -15,8 +15,10 @@ jobs:
         run: |
           pip install .[dev]
       - name: Check code formatting with black
-        run: |
-          pip install black
-          black --check .
+        run: black --check .
+      - name: Lint with flake8
+        run: flake8 src tests
+      - name: Type-check with mypy
+        run: mypy
       - name: Run tests
         run: PYTHONPATH=./src pytest tests/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,8 +31,8 @@ dev = [
     "matplotlib>=3.10",
     "flake8",
     "Flake8-pyproject",
+    "mypy",
     "optuna>=4.3.0",
-    "pyclustertend",
 ]
 
 [tool.setuptools]
@@ -46,10 +46,31 @@ where = ["src"]
 
 [project.scripts]
 optimizers = "optimizers.__init__:main"
-fuzzy = "fuzzy.__init__:main"
 
 [tool.flake8]
 max-line-length = 120
 exclude = ".git,__pycache__,build,dist,.eggs,.tox,.venv,venv"
-include = "./src,./tests"
-extend-ignore = ["E203"]
+# E203 / W503 conflict with black's formatting; ignore per black's guidance.
+extend-ignore = ["E203", "W503"]
+
+[tool.mypy]
+python_version = "3.10"
+files = ["src"]
+# Third-party numeric/plotting libs (numba, kmodes, plotly, joblib, sklearn,
+# scipy) ship no/partial stubs; don't fail on their missing type info.
+ignore_missing_imports = true
+warn_redundant_casts = true
+# The AF/AI aliases are unions of dtype-parameterized numpy arrays, so ordinary
+# array arithmetic trips these categories pervasively (false positives, not
+# bugs). Silence them for now; the real-defect categories (attr-defined,
+# return-value, name-defined, no-redef, call-arg, ...) stay enforced. Ratchet
+# these off as the numeric annotations tighten.
+disable_error_code = [
+    "arg-type",
+    "assignment",
+    "index",
+    "operator",
+    "union-attr",
+    "override",
+    "list-item",
+]

--- a/src/optimizers/combinatorial/aco.py
+++ b/src/optimizers/combinatorial/aco.py
@@ -7,7 +7,7 @@ from joblib import delayed
 from .base import CombinatoricsResult, TSPBase, _check_stop_early
 from .strategy import TwoOptTSPConfig, TwoOptTSP
 from ..core.base import IOptimizerConfig, setup_for_generations
-from ..core.types import AI, AF, F, ab8, i32, i16
+from ..core.types import AI, AF, ab8, i32, i16
 
 
 @dataclass
@@ -169,7 +169,7 @@ def p_xy(eta_beta_xy: AF, tau_alpha_xy: AF, allowed_y: ab8, x: int) -> AF | int:
 
 def run_ant(
     network_routes: AF, eta_beta: AF, tau_alpha: AF, config: AntColonyTSPConfig
-) -> tuple[AI, F]:
+) -> tuple[AI, float]:
     # Start at city 1, and visit each city exactly once
     cur_city = 0  # Offset by 1, so we start at city 1
     eta_shape_ = eta_beta.shape[0]

--- a/src/optimizers/combinatorial/aco_mst.py
+++ b/src/optimizers/combinatorial/aco_mst.py
@@ -1,13 +1,11 @@
-from dataclasses import dataclass
 from typing import Optional
 
 import numpy as np
 from joblib import delayed
 
 from .base import CombinatoricsResult, TSPBase, _check_stop_early
-from .strategy import TwoOptTSPConfig, TwoOptTSP
-from ..core.base import IOptimizerConfig, setup_for_generations
-from ..core.types import AI, AF, F, ab8, i32, i16
+from ..core.base import setup_for_generations
+from ..core.types import AI, AF, ab8, i32, i16
 from .aco import AntColonyTSPConfig
 
 # NOTE - MST is the same as TSP parameters, except the "back to start" is ignored.
@@ -132,7 +130,7 @@ def run_ant_mst(
     tau_alpha: AF,
     config: AntColonyTSPConfig,
     start_idx: int,
-) -> tuple[AI, F]:
+) -> tuple[AI, float]:
     cur_city = start_idx
     order_len = eta_beta.shape[0]
     # If fewer than 32,000 cities, we can use i16

--- a/src/optimizers/combinatorial/base.py
+++ b/src/optimizers/combinatorial/base.py
@@ -18,7 +18,7 @@ class CombinatoricsResult:
 
 def check_path_distance(
     distances: AF, order_path: AI, return_to_start: bool = False
-) -> F:
+) -> float:
     # Sum every consecutive edge in one fancy-indexed gather instead of a scalar
     # Python loop (report item #10). Equivalent to the old loop: the closing edge
     # returns to city 0 (order_path[0] is always the depot in these solvers).
@@ -51,8 +51,9 @@ class TSPBase(ABC):
         network_routes: AF | None = None,
         city_locations: AF | None = None,
     ):
-        self.city_locations = None
-        self.network_routes = None
+        self.city_locations: AF | None = None
+        # Always populated by set_network_routes below.
+        self.network_routes: AF = None
         self.set_network_routes(network_routes, city_locations)
 
     def set_network_routes(

--- a/src/optimizers/combinatorial/ga.py
+++ b/src/optimizers/combinatorial/ga.py
@@ -147,7 +147,7 @@ class GeneticAlgorithmTSP(TSPBase):
 
 def run_ga(
     genome: AI, genome_value: AF, network_routes: AF, config: GeneticAlgorithmTSPConfig
-) -> tuple[AI, F]:
+) -> tuple[AI, float]:
     # Take two parents
     parent_1 = _tournament_selection(genome, genome_value)
     parent_2 = _tournament_selection(genome, genome_value)

--- a/src/optimizers/combinatorial/mtsp.py
+++ b/src/optimizers/combinatorial/mtsp.py
@@ -68,7 +68,7 @@ class AntColonyMTSP:
             variables=variables,
             fcn=goal_fcn,
         )
-        result = solver.solve()
+        solver.solve()
 
         raise ValueError("TSP clustering is not yet supported")
 
@@ -81,8 +81,6 @@ class AntColonyMTSP:
             cluster_cities = self.city_locations[cluster, :]
             cluster_config = create_from_dict(self.config.__dict__, AntColonyTSPConfig)
             cluster_config.name = f"{self.config.name}-{cluster_id + 1}"
-            # Not relevant, but for clarity
-            cluster_config.n_clusters = 1
             tsp_solve = AntColonyTSP(cluster_config, city_locations=cluster_cities)
             cluster_result = tsp_solve.solve()
             # Map cluster indices back to original indices
@@ -95,7 +93,7 @@ class AntColonyMTSP:
         optimal_paths = [result.optimal_path for result in results]
 
         return CombinatoricsResult(
-            value_history=[result.value_history for result in results],
+            value_history=[result.value_history for result in results],  # type: ignore[misc]
             optimal_value=np.sum([result.optimal_value for result in results]),
             stop_reason="max_iterations",
             optimal_path=optimal_paths,
@@ -125,7 +123,7 @@ class AntColonyMTSP:
                 n_clusters=self.config.n_clusters, assign_labels="discretize"
             )
             cluster_labels = sc.fit_predict(self.city_locations)
-            clusters: list[list[int]] = [[] for _ in range(self.config.n_clusters)]
+            clusters = [[] for _ in range(self.config.n_clusters)]
             for i, label in enumerate(cluster_labels):
                 clusters[label].append(i)
             return clusters

--- a/src/optimizers/combinatorial/strategy.py
+++ b/src/optimizers/combinatorial/strategy.py
@@ -1,4 +1,3 @@
-import heapq
 from dataclasses import dataclass
 from typing import Optional
 
@@ -229,7 +228,7 @@ class TwoOptTSP(TSPBase):
         )
 
     def setup_local_search(self) -> tuple[int, AI]:
-        if self.initial_route is None or self.initial_value == None:
+        if self.initial_route is None or self.initial_value is None:
             # Use the nearest neighbor
             nn_config = NearestNeighborTSPConfig(
                 back_to_start=self.config.back_to_start, name=self.config.name

--- a/src/optimizers/continuous/aco.py
+++ b/src/optimizers/continuous/aco.py
@@ -1,6 +1,5 @@
 from dataclasses import dataclass
 
-import joblib
 import numpy as np
 
 from .local import apply_local_optimization
@@ -8,7 +7,6 @@ from ..core.base import (
     IOptimizerConfig,
     OptimizerResult,
     OptimizerRun,
-    LocalOptimType,
     GoalFcn,
     InputArguments,
 )
@@ -17,7 +15,6 @@ from ..core.parallel import GenerationRunner
 from ..core.types import af64
 from ..solution_deck import (
     SolutionDeck,
-    WrappedGoalFcn,
 )
 from ..core.random import rng as global_rng
 

--- a/src/optimizers/continuous/base.py
+++ b/src/optimizers/continuous/base.py
@@ -5,7 +5,7 @@ import numpy as np
 import time
 import uuid
 import inspect
-from typing import Optional, Callable, Any, Literal
+from typing import Optional, Any
 
 from ..core import InputVariables
 from ..core.base import (

--- a/src/optimizers/continuous/ga.py
+++ b/src/optimizers/continuous/ga.py
@@ -1,6 +1,5 @@
 from dataclasses import dataclass
 
-import joblib
 import numpy as np
 from numpy.random import Generator
 
@@ -10,7 +9,6 @@ from ..core.base import (
     OptimizerResult,
     IOptimizerConfig,
     OptimizerRun,
-    LocalOptimType,
     GoalFcn,
     InputArguments,
 )
@@ -25,7 +23,6 @@ from .base import IOptimizer
 
 from ..solution_deck import (
     SolutionDeck,
-    WrappedGoalFcn,
 )
 
 
@@ -95,7 +92,7 @@ def _mutate_batch(
         if col_mask.any():
             perturbed = variable.perturb_values(out[:, ij], rng=rng)
             out[col_mask, ij] = perturbed[col_mask]
-    return out
+    return out  # type: ignore[return-value]  # np.copy loses dtype param
 
 
 def run_ga(

--- a/src/optimizers/continuous/local.py
+++ b/src/optimizers/continuous/local.py
@@ -3,7 +3,7 @@ from ..core.base import LocalOptimType, ensure_literal_choice
 from ..solution_deck import WrappedGoalFcn
 from .variables import InputVariable, InputDiscreteVariable
 from ..core.types import AF, F
-from typing import get_args, Optional
+from typing import get_args
 
 
 def apply_local_optimization(

--- a/src/optimizers/continuous/optimizer_strategy.py
+++ b/src/optimizers/continuous/optimizer_strategy.py
@@ -198,7 +198,7 @@ class GroupedVariableOptimizer(IOptimizer):
                     return self.wrapped_fcn(y)
 
                 config = config_to_type(self.config, group.optimizer_type)
-                optimizer: IOptimizer
+                optim: IOptimizer
                 if group.optimizer_type == "aco":
                     optim = AntColonyOptimizer(config, new_fcn, group_vars)
                 elif group.optimizer_type == "pso":

--- a/src/optimizers/continuous/pso.py
+++ b/src/optimizers/continuous/pso.py
@@ -1,6 +1,5 @@
 from dataclasses import dataclass
 
-import joblib
 import numpy as np
 
 from ..core.base import (
@@ -10,7 +9,6 @@ from ..core.base import (
 )
 from ..core.types import AF, F
 from ..solution_deck import (
-    WrappedGoalFcn,
     InputVariables,
     SolutionDeck,
 )

--- a/src/optimizers/continuous/step.py
+++ b/src/optimizers/continuous/step.py
@@ -15,7 +15,6 @@ from ..solution_deck import SolutionDeck
 class StepWiseOptimizerConfig(IOptimizerConfig):
     optimize_whole_solution_deck: bool = False
     max_perturbation: float = 0.1  # Fraction of domain
-    pass
 
 
 class StepWiseOptimizer(IOptimizer):

--- a/src/optimizers/core/parallel.py
+++ b/src/optimizers/core/parallel.py
@@ -124,6 +124,7 @@ class GenerationRunner:
                 for _ in range(n)
             ]
             return [f.result() for f in futures]
+        assert self._parallel is not None
         return self._parallel(
             joblib.delayed(worker_fn)(self._fixed, *varying_args) for _ in range(n)
         )

--- a/src/optimizers/core/random.py
+++ b/src/optimizers/core/random.py
@@ -44,7 +44,6 @@ def rng() -> np.random.Generator:
     fresh entropy so default behavior remains non-deterministic unless the
     caller opted in via set_seed(...).
     """
-    global _global_rng
     if _global_rng is None:
         set_seed(None)
     assert _global_rng is not None

--- a/src/optimizers/core/types.py
+++ b/src/optimizers/core/types.py
@@ -23,5 +23,5 @@ T = typing.TypeVar("T")
 AF = typing.Union[af64, af32, af16]
 AI = typing.Union[ai64, ai32, ai16]
 F = typing.Union[f64, f32, f16]
-I = typing.Union[i64, i32, i16]
+I = typing.Union[i64, i32, i16]  # noqa: E741  (type alias, not a variable)
 B = typing.Union[b8]

--- a/src/optimizers/core/variables.py
+++ b/src/optimizers/core/variables.py
@@ -1,5 +1,4 @@
 from abc import ABC, abstractmethod
-from dataclasses import dataclass
 
 import numpy as np
 from numpy.random import Generator

--- a/src/optimizers/solution_deck.py
+++ b/src/optimizers/solution_deck.py
@@ -7,7 +7,7 @@ from kmodes.kmodes import KModes
 
 from .core.base import ensure_literal_choice, WrappedGoalFcn
 from .core.random import get_seed
-from .core.types import f64, af64, ab8, b8, i64
+from .core.types import f64, af64, ab8, b8
 from .core.variables import InputVariables
 
 # Some type hinting
@@ -238,7 +238,7 @@ def lloyds_algorithm_points(n: int, k: int, n_steps: int = 10) -> af64:
     points = np.sort(np.random.random(size=(n, k)), axis=0)
 
     for step in range(n_steps):
-        labels = kmeans.fit_predict(points)
+        kmeans.fit_predict(points)
         centers = kmeans.cluster_centers_
         centers = np.sort(centers, axis=0)
         # Early stopping if converged
@@ -283,8 +283,7 @@ def fibonacci_sphere_points(n: int, k: int) -> af64:
         points[:, j] *= np.cos(theta[:, j])
         points[:, (j + 1) :] *= np.sin(theta[:, j])[:, np.newaxis]
 
-    r = np.logspace(-1.0, 0.0, n)
-    # points = points * r[:, np.newaxis]
+    # points = points * np.logspace(-1.0, 0.0, n)[:, np.newaxis]
 
     # Inscribe the unit-ball in the unit hyper-cube
     points /= np.max(np.linalg.norm(points, axis=1))
@@ -293,7 +292,7 @@ def fibonacci_sphere_points(n: int, k: int) -> af64:
     return points
 
 
-def inv_elliptic2(s: f64, m: f64) -> f64:
+def inv_elliptic2(s: f64, m: f64) -> float:
     # Solve the inverse second incomplete elliptic integral of the second kind
     # https://en.wikipedia.org/wiki/Incomplete_elliptic_integral
     # s = integral from 0 to alpha of sqrt(1-m*sin^2 t) dt
@@ -314,7 +313,8 @@ def inv_elliptic2(s: f64, m: f64) -> f64:
 @lru_cache(maxsize=16)
 def spiral_points(n: int, k: int) -> af64:
     """
-    Generates N points in a k-dimensional space using rotation matrices. Source: https://www.fujipress.jp/jaciii/jc/jacii001500081116/
+    Generates N points in a k-dimensional space using rotation matrices.
+    Source: https://www.fujipress.jp/jaciii/jc/jacii001500081116/
 
     Args:
         n (int): Number of points.

--- a/tests/test_runtime_args.py
+++ b/tests/test_runtime_args.py
@@ -1,4 +1,3 @@
-import time
 import numpy as np
 import pytest
 
@@ -37,7 +36,6 @@ def test_phase_literal_definition():
 def test_metadata_injection_into_goal_and_constraints(tiny_ga_cfg):
     # Record snapshots of metadata seen inside the functions
     seen_goal = []
-    seen_cons = []
 
     user_args = {"note": "hello", "generation": -123}  # collision: metadata should win
 


### PR DESCRIPTION
## What

Adds real static lint/type enforcement to CI and makes the tree pass it. Fourth in the sequence — stacks on #77 (→ #76 → main).

### CI (`.github/workflows/pr.yml`)
- **flake8** and **mypy** now run as gated steps (after black, before pytest).
- Trigger broadened to **every PR** (not just those targeting `main`) so stacked PRs get checked — this is why #77 initially showed no checks.

### flake8
Config: dropped the invalid `include` key, added `W503` to the black-compatible ignores (`max-line-length` stays 120). Fixed all **28** findings — unused imports (via autoflake), dead locals, an `== None`, a redundant `global`, one over-long docstring line; `# noqa: E741` on the `I` type alias.

### mypy (new `[tool.mypy]`)
Pragmatic starting config: `ignore_missing_imports` (numba/kmodes/plotly/joblib/sklearn/scipy ship no or partial stubs) and `disable_error_code` for the categories dominated by numpy dtype-union false positives (`arg-type`, `assignment`, `index`, `operator`, `union-attr`, `override`, `list-item`). The real-defect categories (`attr-defined`, `return-value`, `name-defined`, `no-redef`, `call-arg`, …) stay **enforced**. This is a starting point — we can ratchet the disabled codes off as the numeric annotations tighten.

Fixed all **16** real findings, notably:
- `TSPBase.network_routes` / `.city_locations` were inferred as `None` (init'd to `None`), so every downstream `.shape` errored — now typed.
- Honest return types: `check_path_distance` / `run_ant` / `run_ga` / `inv_elliptic2` return a Python `float`, not a numpy-scalar alias.
- **Latent-bug catch:** `mtsp` set `cluster_config.n_clusters = 1` on an `AntColonyTSPConfig` that has no such field (a silent no-op — same class of typo as the earlier `n_jobs` one); removed.

### Cleanup
Removed the dead `fuzzy` console-script entry (package removed in #75) and the now-unused `pyclustertend` dev dep; added `mypy` to dev deps.

## Merge order

Stacks on #77. Merge **#76 → #77 → this**. The diff here is just the lint commit.

## Testing

`black --check .`, `flake8 src tests`, and `mypy` all clean; full suite **20 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)