### PR TITLE
chore(lint): ratchet mypy up one notch (operator + union-attr None-safety)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,14 +63,16 @@ warn_redundant_casts = true
 # The AF/AI aliases are unions of dtype-parameterized numpy arrays, so ordinary
 # array arithmetic trips these categories pervasively (false positives, not
 # bugs). Silence them for now; the real-defect categories (attr-defined,
-# return-value, name-defined, no-redef, call-arg, ...) stay enforced. Ratchet
-# these off as the numeric annotations tighten.
+# return-value, name-defined, no-redef, call-arg, operator, union-attr, ...)
+# stay enforced. Ratchet these off as the numeric annotations tighten.
+#
+# Ratchet log:
+#   * operator + union-attr enabled (None-safety pass) — caught real bugs
+#     (dividing by an optional hot_start_length, iterating an optional groups).
 disable_error_code = [
     "arg-type",
     "assignment",
     "index",
-    "operator",
-    "union-attr",
     "override",
     "list-item",
 ]

--- a/src/optimizers/combinatorial/aco.py
+++ b/src/optimizers/combinatorial/aco.py
@@ -57,6 +57,10 @@ class AntColonyTSP(TSPBase):
         tour_lengths = []
         optimal_tour_length = np.inf
         if self.config.hot_start is not None:
+            if self.config.hot_start_length is None:
+                raise ValueError(
+                    "hot_start_length must be provided when hot_start is set"
+                )
             optimal_tour_length = self.config.hot_start_length
             optimal_city_order = self.config.hot_start
             for i in range(len(self.config.hot_start) - 1):
@@ -152,7 +156,7 @@ def pheromone_update(tau_xy: AF, delta_tau_xy: AF, rho: float) -> AF:
     return new_tau_xy / new_tau_xy.max()
 
 
-def p_xy(eta_beta_xy: AF, tau_alpha_xy: AF, allowed_y: ab8, x: int) -> AF | int:
+def p_xy(eta_beta_xy: AF, tau_alpha_xy: AF, allowed_y: ab8, x: int) -> AF:
     # ``eta_beta``/``tau_alpha`` are already raised to beta/alpha upstream
     # (report item #6), so this is a single elementwise product per step.
     p = tau_alpha_xy[x, :] * eta_beta_xy[x, :]
@@ -162,7 +166,8 @@ def p_xy(eta_beta_xy: AF, tau_alpha_xy: AF, allowed_y: ab8, x: int) -> AF | int:
     # Normalize the probabilities
     total = p.sum()
     if total == 0.0:
-        return 0
+        # all-zero (un-normalized) array; callers test np.sum(p) == 0
+        return p
     p /= total
     return p
 

--- a/src/optimizers/combinatorial/aco_mst.py
+++ b/src/optimizers/combinatorial/aco_mst.py
@@ -35,6 +35,10 @@ class AntColonyMST(TSPBase):
         tour_lengths = []
         optimal_tour_length = np.inf
         if self.config.hot_start is not None:
+            if self.config.hot_start_length is None:
+                raise ValueError(
+                    "hot_start_length must be provided when hot_start is set"
+                )
             optimal_tour_length = self.config.hot_start_length
             optimal_city_order = self.config.hot_start
             for ij in range(self.config.hot_start.shape[0]):
@@ -110,7 +114,7 @@ def pheromone_update(tau_xy: AF, delta_tau_xy: AF, rho: float) -> AF:
     return new_tau_xy / new_tau_xy.max()
 
 
-def p_xy(eta_beta_xy: AF, tau_alpha_xy: AF, allowed_y: ab8) -> AF | int:
+def p_xy(eta_beta_xy: AF, tau_alpha_xy: AF, allowed_y: ab8) -> AF:
     # ``eta_beta``/``tau_alpha`` are pre-raised to beta/alpha upstream (#6).
     p = tau_alpha_xy[~allowed_y, :] * eta_beta_xy[~allowed_y, :]
     # Remove negative probabilities, those are not allowed
@@ -119,7 +123,8 @@ def p_xy(eta_beta_xy: AF, tau_alpha_xy: AF, allowed_y: ab8) -> AF | int:
     # Normalize the probabilities
     total = p.sum()
     if total == 0.0:
-        return 0
+        # all-zero (un-normalized) array; callers test np.sum(p) == 0
+        return p
     p /= total
     return p
 
@@ -163,7 +168,8 @@ def run_ant_mst(
         # Choose the next city-pair, must flatten probability matrix first
         cum_p = np.cumsum(p.flatten())
         new_p = np.random.random()
-        choice_idx = np.argmin(new_p > cum_p)
+        # float > ndarray is a valid elementwise compare; numpy stubs mistype it
+        choice_idx = np.argmin(new_p > cum_p)  # type: ignore[operator]
         from_row = choice_idx // order_len
         from_col = choice_idx % order_len
         city_order[idx, 0] = from_row

--- a/src/optimizers/combinatorial/strategy.py
+++ b/src/optimizers/combinatorial/strategy.py
@@ -241,6 +241,7 @@ class TwoOptTSP(TSPBase):
             solution = nn_solver.solve()
             self.initial_route = solution.optimal_path
             self.initial_value = solution.optimal_value
+        assert self.initial_route is not None
         new_route = self.initial_route.copy()
         N = self.network_routes.shape[0]
         return N, new_route
@@ -369,6 +370,8 @@ class ConvexHullTSP(TSPBase):
     def solve(self) -> CombinatoricsResult:
         # Use the windmill method starting at point-0.
         # NOTE - This will give us the convex hull PLUS the sequence required to get there.
+        if self.city_locations is None:
+            raise ValueError("ConvexHullTSP requires city_locations")
         current_node = 0
         total_distance = 0
         tour = [current_node]

--- a/src/optimizers/continuous/optimizer_strategy.py
+++ b/src/optimizers/continuous/optimizer_strategy.py
@@ -188,6 +188,8 @@ class GroupedVariableOptimizer(IOptimizer):
         # TODO - Pass in previous best solution deck
         # TODO - Support for check-pointing!
         default_values = [var.initial_value for var in self.variables]
+        if self.config.groups is None:
+            raise ValueError("GroupedVariableOptimizerConfig.groups must be set")
         for cur_round in range(self.config.num_rounds):
             for group in self.config.groups:
                 group_vars = [v for v in self.variables if v.name in group.variables]

--- a/src/optimizers/core/parallel.py
+++ b/src/optimizers/core/parallel.py
@@ -117,6 +117,7 @@ class GenerationRunner:
         """
         n = self.n_jobs if count is None else count
         if self.prefer == "processes":
+            assert self._executor is not None
             futures = [
                 self._executor.submit(
                     _call_with_fixed, worker_fn, self._token, varying_args


### PR DESCRIPTION
## What

Ratchets mypy up one notch, as a follow-up to #78. Removes **`operator`** and **`union-attr`** from the disabled-codes list — a focused **None-safety** pass. Stacks on #78 (→ #77 → #76 → main).

I picked these two (of the seven disabled codes) because measuring showed they were almost entirely *real bugs*, not numpy-union friction — unlike `arg-type`/`assignment`/`index` which remain disabled for now.

## Real bugs this caught

- **`aco.py` / `aco_mst.py`** — `10 * q / self.config.hot_start_length` divides by a field typed `float | None`. Passing `hot_start` without `hot_start_length` would crash with a `TypeError`; now guarded with a clear `ValueError`.
- **`optimizer_strategy.py`** — `for group in self.config.groups` iterates a field typed `list | None`; guarded with a `ValueError` when unset.
- **`ConvexHullTSP.solve`** — indexed `self.city_locations` (typed `AF | None`) with no guard; now raises a clear `ValueError` instead of a cryptic `AttributeError`.

## Non-bug narrowing (to satisfy the newly-enabled checks)

- `parallel.py`: assert the dedicated executor is set inside the processes branch.
- `strategy.setup_local_search`: assert `initial_route` is set (guaranteed by the block directly above) before `.copy()`.
- `aco`/`aco_mst` `p_xy`: return the already-zeroed array instead of the `int 0` sentinel, so the return type is cleanly `AF` (callers still test `np.sum(p) == 0`). One `# type: ignore[operator]` remains for a `float > ndarray` compare that numpy's stubs mistype.

## Still disabled (future ratchets)

`arg-type`, `assignment`, `index`, `override`, `list-item` — these are dominated by the `AF`/`AI` dtype-union false positives and need real annotation work to enable cleanly.

## Testing

`black --check .`, `flake8 src tests`, `mypy` all clean; full suite **20 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)