### PR TITLE
feat(qd): map MAP-Elites variation into ACO and PSO (solver parity)

### DIFF
--- a/src/optimizers/archive/__init__.py
+++ b/src/optimizers/archive/__init__.py
@@ -10,7 +10,7 @@ MAP-Elites, ``ParetoArchive``) land in later phases of ``QD_PARETO_PLAN.md``.
 from .base import Archive
 from .cvt import CVTArchive
 from .descriptor import RandomProjectionDescriptor, OutputsDescriptor
-from .variation import iso_line_dd
+from .variation import iso_line_dd, iso_line_offspring
 from .metrics import (
     non_dominated_mask,
     pareto_front,
@@ -32,6 +32,7 @@ __all__ = [
     "RandomProjectionDescriptor",
     "OutputsDescriptor",
     "iso_line_dd",
+    "iso_line_offspring",
     "non_dominated_mask",
     "pareto_front",
     "hypervolume",

--- a/src/optimizers/archive/variation.py
+++ b/src/optimizers/archive/variation.py
@@ -54,3 +54,33 @@ def iso_line_dd(
     line = rng.standard_normal((n, 1)) * line_sigma
     children = a + iso + line * (b - a)
     return np.clip(children, lower, upper)
+
+
+def iso_line_offspring(
+    archive: AF,
+    n: int,
+    iso_sigma: float,
+    line_sigma: float,
+    lower: AF,
+    upper: AF,
+    rng: Generator,
+    tournament_k: int = 3,
+) -> AF:
+    """Generate ``n`` Iso+LineDD children from a **best-first sorted** archive.
+
+    Solver-agnostic so GA/ACO/PSO produce offspring identically in map-elites
+    ``qd_variation="iso_line"`` mode (fair for cross-solver comparison). The
+    *base* parent is a rank tournament — the min index of ``tournament_k`` uniform
+    picks, which favours the front because the archive is sorted best-first, so it
+    adds convergence pressure without needing the fitness values. The *direction*
+    parent is uniform over the whole archive (diversity). See QD_PARETO_PLAN.md
+    §4.3.
+    """
+    archive = np.asarray(archive, dtype=float)
+    N = archive.shape[0]
+    k = min(tournament_k, N)
+    base_idx = np.min(rng.integers(0, N, size=(n, k)), axis=1)  # rank tournament
+    dir_idx = rng.integers(0, N, size=n)  # uniform direction
+    return iso_line_dd(
+        archive[base_idx], archive[dir_idx], iso_sigma, line_sigma, lower, upper, rng
+    )

--- a/src/optimizers/continuous/aco.py
+++ b/src/optimizers/continuous/aco.py
@@ -20,6 +20,7 @@ from ..solution_deck import (
     WrappedGoalFcn,
 )
 from ..core.random import rng as global_rng
+from ..archive.variation import iso_line_offspring
 
 from .base import IOptimizer
 from ..core.variables import InputVariables
@@ -41,10 +42,29 @@ def run_ants(
 ) -> OptimizerRun:
     # ``fixed`` is the run-constant payload shipped to each worker once (see
     # core.parallel); ``meta`` is the small per-generation live metadata.
-    arg_provider, variables, fcn, learning_rate, local_optim, n_ants = fixed
+    arg_provider, variables, fcn, learning_rate, local_optim, n_ants, qd = fixed
+    map_elites, variation, iso_sigma, line_sigma, lower, upper = qd
     sync_worker_meta(arg_provider, meta)
     n_vars = len(variables)
     rng = global_rng()
+
+    if map_elites and variation == "iso_line":
+        # Shared Iso+LineDD variation over the diverse CVT archive (same operator
+        # as GA/PSO in this mode, for fair comparison). See QD_PARETO_PLAN.md §4.3.
+        children = iso_line_offspring(
+            solution_archive, n_ants, iso_sigma, line_sigma, lower, upper, rng
+        )
+        ant_solutions = np.empty((n_ants, n_vars))
+        ant_values = np.empty(n_ants)
+        for ant in range(n_ants):
+            new_solution, new_value = apply_local_optimization(
+                fcn, local_optim, children[ant], variables
+            )
+            ant_solutions[ant] = new_solution
+            ant_values[ant] = new_value
+        return OptimizerRun(
+            population_values=ant_values, population_solutions=ant_solutions
+        )
 
     # Each ant picks a single base solution from the archive via the rank CDF
     # (the original drew one p per ant and reused it across every variable).
@@ -109,6 +129,14 @@ class AntColonyOptimizer(IOptimizer):
         ) = self.initialize(preserve_percent)
         # Fixed data (variables, wrapped goal fn, hyper-parameters) is shipped to
         # each worker exactly once; only the archive + CDF vary per generation.
+        qd = (
+            self._objective_mode == "map-elites",
+            self.config.qd_variation,
+            self.config.iso_sigma,
+            self.config.line_sigma,
+            np.array([v.lower_bound for v in self.variables], dtype=float),
+            np.array([v.upper_bound for v in self.variables], dtype=float),
+        )
         fixed = (
             self._arg_provider,
             self.variables,
@@ -116,6 +144,7 @@ class AntColonyOptimizer(IOptimizer):
             self.config.learning_rate,
             self.config.local_grad_optim,
             individuals_per_job,
+            qd,
         )
         runner = GenerationRunner(n_jobs, self.config.joblib_prefer, fixed)
         try:

--- a/src/optimizers/continuous/ga.py
+++ b/src/optimizers/continuous/ga.py
@@ -21,7 +21,7 @@ from .base import (
 from ..core.variables import InputVariables
 from ..core.random import rng as global_rng
 from ..core.parallel import GenerationRunner
-from ..archive.variation import iso_line_dd
+from ..archive.variation import iso_line_offspring
 from .base import IOptimizer
 
 from ..solution_deck import (
@@ -122,28 +122,10 @@ def run_ga(
     rng = global_rng()
 
     if map_elites and variation == "iso_line":
-        # MAP-Elites variation (QD_PARETO_PLAN.md §4.3), tuned for exploration
-        # *and* convergence: the **base** parent is chosen by tournament (fitness
-        # pressure → drives the global best down), while the **direction** parent
-        # is drawn uniformly across the archive's occupied cells (structural
-        # diversity → escapes local optima). Iso+LineDD then steps the fit base
-        # along the diverse inter-elite direction — far more effective than
-        # isotropic mutation in high dimensions. The CVT archive keeps the pool
-        # diverse (one elite per cell), so tournament here is not the premature-
-        # convergence trap it is on a scalar deck of near-duplicates.
-        base = _tournament_selection_batch(
-            solution_archive, solution_values, n_steps, rng=rng
-        )
-        n = solution_archive.shape[0]
-        direction = solution_archive[rng.integers(0, n, size=n_steps)]
-        children = iso_line_dd(
-            base,
-            direction,
-            iso_sigma,
-            line_sigma,
-            lower,
-            upper,
-            rng,
+        # Shared Iso+LineDD variation over the diverse CVT archive (identical
+        # across GA/ACO/PSO for fair comparison). See QD_PARETO_PLAN.md §4.3.
+        children = iso_line_offspring(
+            solution_archive, n_steps, iso_sigma, line_sigma, lower, upper, rng
         )
         new_population = np.empty((n_steps, len(variables)))
         new_population_fitness = np.empty(n_steps)

--- a/src/optimizers/continuous/pso.py
+++ b/src/optimizers/continuous/pso.py
@@ -8,7 +8,7 @@ from ..core.base import (
     OptimizerResult,
     OptimizerRun,
 )
-from ..core.types import AF, F
+from ..core.types import AF
 from ..solution_deck import (
     WrappedGoalFcn,
     InputVariables,
@@ -23,6 +23,8 @@ from .base import (
 )
 from ..core.random import rng as global_rng
 from ..core.parallel import GenerationRunner
+from ..archive.variation import iso_line_offspring
+from .local import apply_local_optimization
 
 
 @dataclass
@@ -39,8 +41,8 @@ class ParticleSwarmOptimizerConfig(IOptimizerConfig):
 def run_particles(
     fixed: tuple,
     meta: InputArguments,
-    global_best_position: AF,
-    global_best_value: F,
+    solution_archive: AF,
+    solution_values: AF,
 ) -> OptimizerRun:
     """
     Generate new candidate solutions using a PSO-inspired step that leverages the
@@ -62,10 +64,31 @@ def run_particles(
         social,
         velocity_clamp,
         n_particles,
+        local_optim,
+        qd,
     ) = fixed
+    map_elites, variation, iso_sigma, line_sigma, lower, upper = qd
     sync_worker_meta(arg_provider, meta)
     rng = global_rng()
     n_vars = len(variables)
+
+    if map_elites and variation == "iso_line":
+        # Shared Iso+LineDD variation over the diverse CVT archive (same operator
+        # as GA/ACO in this mode, for fair comparison). See QD_PARETO_PLAN.md §4.3.
+        children = iso_line_offspring(
+            solution_archive, n_particles, iso_sigma, line_sigma, lower, upper, rng
+        )
+        positions = np.empty((n_particles, n_vars))
+        values = np.empty(n_particles)
+        for k in range(n_particles):
+            s, v = apply_local_optimization(fcn, local_optim, children[k], variables)
+            positions[k] = s
+            values[k] = v
+        return OptimizerRun(population_values=values, population_solutions=positions)
+
+    # Native PSO path: global best is the archive's top entry (best-first).
+    global_best_position = solution_archive[0, :]
+    global_best_value = solution_values[0]
     # Per-variable domains, used to clamp velocity (constant across the run).
     domains = np.array([v.domain for v in variables])
 
@@ -149,6 +172,14 @@ class ParticleSwarmOptimizer(IOptimizer):
         ) = self.initialize(preserve_percent)
         # Ship fixed data (variables, goal fn, PSO coefficients) to each worker
         # once; only the current global best varies per generation.
+        qd = (
+            self._objective_mode == "map-elites",
+            self.config.qd_variation,
+            self.config.iso_sigma,
+            self.config.line_sigma,
+            np.array([v.lower_bound for v in self.variables], dtype=float),
+            np.array([v.upper_bound for v in self.variables], dtype=float),
+        )
         fixed = (
             self._arg_provider,
             self.variables,
@@ -158,6 +189,8 @@ class ParticleSwarmOptimizer(IOptimizer):
             self.config.social,
             self.config.velocity_clamp,
             individuals_per_job,
+            self.config.local_grad_optim,
+            qd,
         )
         runner = GenerationRunner(n_jobs, self.config.joblib_prefer, fixed)
         try:
@@ -176,8 +209,8 @@ class ParticleSwarmOptimizer(IOptimizer):
                     run_particles,
                     (
                         self.live_meta(),
-                        self.soln_deck.solution_archive[0, :],
-                        self.soln_deck.solution_value[0],
+                        self.soln_deck.solution_archive,
+                        self.soln_deck.solution_value,
                     ),
                 )
 

--- a/src/optimizers/core/base.py
+++ b/src/optimizers/core/base.py
@@ -133,12 +133,14 @@ class IOptimizerConfig:
     """Dimensionality of the MAP-Elites descriptor / projection target."""
     archive_cells: int = 256
     """Number of MAP-Elites (CVT) cells — the archive capacity in map-elites mode."""
-    qd_variation: Literal["ga", "iso_line"] = "ga"
-    """MAP-Elites variation operator. ``"ga"`` (default) keeps the solver's own
-    crossover/mutation but sources parents from the diverse CVT archive — this
-    preserves convergence while the archive curbs premature convergence.
-    ``"iso_line"`` uses the Iso+LineDD operator (more explorative; can lag on
-    smooth, well-structured objectives)."""
+    qd_variation: Literal["native", "iso_line"] = "native"
+    """MAP-Elites variation operator, applied uniformly to GA/ACO/PSO.
+    ``"native"`` (default) keeps each solver's own operator (GA crossover, ACO
+    ant sampling, PSO velocity) but sources parents from the diverse CVT archive —
+    preserving convergence while the archive curbs premature convergence.
+    ``"iso_line"`` replaces it with the shared Iso+LineDD operator for every
+    solver (more explorative; can lag on smooth objectives; makes the three
+    solvers directly comparable under one variation operator)."""
     iso_sigma: float = 0.01
     """Iso+LineDD isotropic std-dev, as a fraction of each variable's domain."""
     line_sigma: float = 0.2

--- a/tests/test_map_elites.py
+++ b/tests/test_map_elites.py
@@ -6,6 +6,7 @@ untouched.
 """
 
 import numpy as np
+import pytest
 
 from optimizers.archive import (
     CVTArchive,
@@ -18,8 +19,43 @@ from optimizers.continuous.ga import (
     GeneticAlgorithmOptimizerConfig,
 )
 from optimizers.continuous.aco import AntColonyOptimizer, AntColonyOptimizerConfig
+from optimizers.continuous.pso import (
+    ParticleSwarmOptimizer,
+    ParticleSwarmOptimizerConfig,
+)
 from optimizers.continuous.variables import InputContinuousVariable
 from optimizers.core.random import set_seed
+
+_QD_SOLVERS = [
+    (GeneticAlgorithmOptimizer, GeneticAlgorithmOptimizerConfig),
+    (AntColonyOptimizer, AntColonyOptimizerConfig),
+    (ParticleSwarmOptimizer, ParticleSwarmOptimizerConfig),
+]
+
+
+@pytest.mark.parametrize("opt_cls,cfg_cls", _QD_SOLVERS)
+@pytest.mark.parametrize("variation", ["native", "iso_line"])
+def test_all_solvers_map_elites(opt_cls, cfg_cls, variation):
+    """GA, ACO and PSO all run in map-elites mode with either variation, build a
+    CVT archive, fill cells, and keep a best-first scalar surface."""
+    set_seed(5)
+    cfg = cfg_cls(
+        name="me",
+        num_generations=10,
+        population_size=30,
+        n_jobs=2,
+        joblib_prefer="threads",
+        objective_mode="map-elites",
+        descriptor_dim=2,
+        archive_cells=24,
+        qd_variation=variation,
+        stop_after_iterations=999,
+    )
+    opt = opt_cls(cfg, _sphere, _vars(), args={})
+    opt.solve()
+    assert isinstance(opt.soln_deck, CVTArchive)
+    assert opt.soln_deck.coverage > 0.2
+    assert np.all(np.diff(opt.soln_deck.solution_value) >= 0)
 
 
 def _vars(n=6):


### PR DESCRIPTION
## What

Brings **ACO and PSO** to full parity with GA under the quality-diversity framework, so all three continuous solvers are directly comparable for the upcoming comparison work. Stacks on #83.

Since Phase 2, all three already shared the diverse **CVT archive** in map-elites mode (native dynamics over a diverse memory). This PR adds the **variation-operator** axis to ACO and PSO too.

## Changes

- **Shared `iso_line_offspring` helper** (`archive/variation.py`): rank-tournament base (favours the best-first archive → convergence pressure) + uniform direction parent (diversity), then Iso+LineDD. Solver-agnostic, so the `iso_line` path is *identical* across GA/ACO/PSO — a fair cross-solver comparison.
- **ACO** (`run_ants`) and **PSO** (`run_particles`) gain the map-elites `iso_line` branch via a `qd` payload in their fixed data, mirroring GA. PSO now receives the **full archive** (not just the global best) so it can draw diverse parents; its native path simply reads the global best as `archive[0]`.
- **Config rename** `qd_variation`: `"ga"` → **`"native"`** (default), since the knob now spans all three solvers:
  - `"native"` — each solver's own operator (GA crossover, ACO ant sampling, PSO velocity) over the diverse archive;
  - `"iso_line"` — the shared Iso+LineDD operator for every solver.

## The comparison matrix this unlocks

| solver | scalar | map-elites `native` | map-elites `iso_line` |
|---|---|---|---|
| GA / ACO / PSO | ✓ | ✓ | ✓ |

Smoke run (8-D sphere, full coverage in all QD cells): ACO improves on its scalar result under `native`; PSO improves under `iso_line`. `qd_report()` (coverage / QD-score / Pareto front) works for all three since it lives on the base class.

## Testing
- Parametrized `test_all_solvers_map_elites` (3 solvers × 2 variations) added; `tests/test_map_elites.py` **17 passed**, full QD suite **35 passed**, existing suites green (incl. PSO scalar after the signature change).
- New code black / flake8 / mypy clean (remaining F401s in the solver modules are pre-existing on `main`, fixed by the lint stack #76).

Merge order: #76 → … → #81 → #82 → #83 → this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)