### PR TITLE
feat(plot): matplotlib backend + global offline/no-show flag

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ requires-python = ">=3.10,<3.15"
 keywords = ["optimization", "GA", "PSO", "ACO", "GD"]
 dependencies = [
     "numpy>=1.21",
-    "plotly>=6.0.0",
+    "matplotlib>=3.10",
     "tqdm>=4.60",
     "joblib>=1.0",
     "contextlib2>=0.6.0",
@@ -28,7 +28,6 @@ dependencies = [
 dev = [
     "pytest>=6.0",
     "black>=24.0",
-    "matplotlib>=3.10",
     "flake8",
     "Flake8-pyproject",
     "optuna>=4.3.0",

--- a/src/optimizers/__init__.py
+++ b/src/optimizers/__init__.py
@@ -21,7 +21,12 @@ from optimizers.checkpoint import (
     load_checkpoint,
     run_multiple,
 )
-from optimizers.plot import plot_convergence, plot_run_statistics
+from optimizers.plot import (
+    plot_convergence,
+    plot_run_statistics,
+    set_show_plots,
+    show_plots_enabled,
+)
 from optimizers.core.random import set_seed, get_seed
 
 __all__ = [
@@ -41,6 +46,8 @@ __all__ = [
     "run_multiple",
     "plot_convergence",
     "plot_run_statistics",
+    "set_show_plots",
+    "show_plots_enabled",
     "set_seed",
     "get_seed",
 ]

--- a/src/optimizers/plot/__init__.py
+++ b/src/optimizers/plot/__init__.py
@@ -1,118 +1,140 @@
+import os
 from typing import Any
 
-import numpy as np
-import plotly.graph_objects as go
-from plotly.subplots import make_subplots
+import matplotlib
 
-from ..core.types import AF, AI
+_TRUTHY = {"1", "true", "yes", "on"}
+
+
+def _env_no_show() -> bool:
+    """Whether the ``OPTIMIZERS_NO_SHOW`` environment variable disables display."""
+    return os.environ.get("OPTIMIZERS_NO_SHOW", "").strip().lower() in _TRUTHY
+
+
+# Select a non-interactive backend *before* pyplot is imported when display is
+# disabled, so that importing this module never tries to reach a screen/browser.
+# This is what makes the library safe for headless/agentic/CI runs.
+if _env_no_show():
+    matplotlib.use("Agg")
+
+import matplotlib.pyplot as plt  # noqa: E402
+import numpy as np  # noqa: E402
+from matplotlib.figure import Figure  # noqa: E402
+
+from ..core.types import AF, AI  # noqa: E402
+
+# Global runtime toggle. Defaults to the env var, but can be flipped at runtime
+# via ``set_show_plots`` (e.g. from a pytest fixture) without touching the env.
+_show_plots = not _env_no_show()
+
+
+def set_show_plots(enabled: bool) -> None:
+    """Globally enable or disable interactive display of plots.
+
+    When disabled, plotting functions build and return the figure but do not
+    call ``plt.show()`` (the figure is closed to free memory). This is the
+    switch tests and agents use to run fully offline.
+    """
+    global _show_plots
+    _show_plots = enabled
+
+
+def show_plots_enabled() -> bool:
+    """Return whether plots are currently displayed when created."""
+    return _show_plots
+
+
+def _finish(fig: Figure) -> Figure:
+    """Show the figure if display is enabled, otherwise close it. Returns the figure."""
+    if _show_plots:
+        plt.show()
+    else:
+        plt.close(fig)
+    return fig
 
 
 def plot_convergence(
     tour_lengths: np.ndarray | list[np.ndarray], trace_names: list[str] | None = None
-) -> None:
-    # Create the figure
-    fig = go.Figure()
-
+) -> Figure:
     if not isinstance(tour_lengths, list):
         tour_lengths = tour_lengths.reshape(1, -1)
 
-    # Add the line trace
+    fig, ax = plt.subplots(figsize=(8, 5))
+
     for i_t, trace in enumerate(tour_lengths):
-        fig.add_trace(
-            go.Scatter(
-                x=np.r_[0 : len(trace)],
-                y=trace,
-                mode="lines+markers",
-                name=trace_names[i_t] if trace_names else f"Run-{i_t+1}",
-                line=dict(width=2),
-                marker=dict(size=6),
-            )
+        ax.plot(
+            np.arange(len(trace)),
+            trace,
+            marker="o",
+            markersize=4,
+            linewidth=2,
+            label=trace_names[i_t] if trace_names else f"Run-{i_t + 1}",
         )
 
-    # Update layout
-    fig.update_layout(
-        title="Convergence",
-        xaxis_title="Generation",
-        yaxis_title="Output Value",
-        template="plotly_white",
-        hovermode="x unified",
-        legend=dict(orientation="h", yanchor="bottom", y=1.02, xanchor="right", x=1),
-    )
+    ax.set_title("Convergence")
+    ax.set_xlabel("Generation")
+    ax.set_ylabel("Output Value")
+    ax.grid(True, alpha=0.3)
+    ax.legend(loc="upper right")
+    fig.tight_layout()
 
-    # Show the figure
-    fig.show()
+    return _finish(fig)
 
 
 def plot_cities_and_route(
     cities: AF, route: AI | list[AI], trace_names: list[str] | None = None
-) -> None:
-    fig = go.Figure()
+) -> Figure:
+    fig, ax = plt.subplots(figsize=(8, 8))
 
     # Plot cities
-    fig.add_trace(
-        go.Scatter(
-            x=cities[:, 0],
-            y=cities[:, 1],
-            mode="markers",
-            name="Cities",
-            marker=dict(size=8, color="blue"),
-        )
-    )
+    ax.scatter(cities[:, 0], cities[:, 1], s=64, c="blue", label="Cities", zorder=3)
 
     if not isinstance(route, list):
         route = [route]
 
-    # Plot route
-    for ir, route in enumerate(route):
-        # If 1D, this is a tour, if 2D, this is a route
-        if route.ndim == 1:
-            route_cities = np.vstack(
-                (cities[route], cities[route[0]])
-            )  # Connect back to start
-            fig.add_trace(
-                go.Scatter(
-                    x=route_cities[:, 0],
-                    y=route_cities[:, 1],
-                    mode="lines",
-                    name=trace_names[ir] if trace_names else f"Route-{ir+1}",
-                    line=dict(width=2),
-                )
+    # Plot route(s)
+    for ir, r in enumerate(route):
+        # If 1D, this is a tour; if 2D, this is a route/MST.
+        if r.ndim == 1:
+            route_cities = np.vstack((cities[r], cities[r[0]]))  # Connect back to start
+            ax.plot(
+                route_cities[:, 0],
+                route_cities[:, 1],
+                linewidth=2,
+                label=trace_names[ir] if trace_names else f"Route-{ir + 1}",
             )
-        elif route.ndim == 2:
-            x_route = list()
-            y_route = list()
-            for _, r in enumerate(route):
-                x_route.extend(cities[r, 0][:])
-                y_route.extend(cities[r, 1][:])
-                x_route.append(None)
-                y_route.append(None)
-            fig.add_trace(
-                go.Scatter(
-                    x=x_route,
-                    y=y_route,
-                    mode="lines",
-                    name=trace_names[ir] if trace_names else f"MST-{ir+1}",
-                    line=dict(width=2),
-                )
+        elif r.ndim == 2:
+            x_route: list[float] = list()
+            y_route: list[float] = list()
+            for seg in r:
+                x_route.extend(cities[seg, 0][:])
+                y_route.extend(cities[seg, 1][:])
+                # NaN breaks the line between disjoint segments (matplotlib
+                # equivalent of plotly's ``None`` gap markers).
+                x_route.append(np.nan)
+                y_route.append(np.nan)
+            ax.plot(
+                x_route,
+                y_route,
+                linewidth=2,
+                label=trace_names[ir] if trace_names else f"MST-{ir + 1}",
             )
 
-    fig.update_layout(
-        title="TSP Route",
-        xaxis_title="X",
-        yaxis_title="Y",
-        showlegend=True,
-        template="plotly_white",
-        yaxis=dict(scaleanchor="x", scaleratio=1),
-    )
+    ax.set_title("TSP Route")
+    ax.set_xlabel("X")
+    ax.set_ylabel("Y")
+    ax.set_aspect("equal", adjustable="datalim")
+    ax.legend(loc="best")
+    fig.tight_layout()
 
-    fig.show()
+    return _finish(fig)
 
 
 def plot_run_statistics(
     summary_or_scores: dict[str, Any] | np.ndarray | list[float],
     runtimes: np.ndarray | list[float] | None = None,
     title_prefix: str = "Run Statistics",
-) -> None:
+) -> Figure:
     """Render box-and-whisker plots for final scores and total runtimes across runs.
 
     Parameters
@@ -132,39 +154,19 @@ def plot_run_statistics(
         scores = np.asarray(summary_or_scores, dtype=float)
         rtimes = np.asarray(runtimes if runtimes is not None else [], dtype=float)
 
-    # Create two subplots vertically using specifications
-    fig = make_subplots(rows=1, cols=2, specs=[[{"type": "box"}, {"type": "box"}]])
+    fig, (ax_scores, ax_rtimes) = plt.subplots(1, 2, figsize=(10, 5))
 
-    # Box for Scores
-    fig.add_trace(
-        go.Box(
-            y=scores,
-            name="Final Score",
-            boxmean=True,
-            marker_color="#1f77b4",
-        ),
-        row=1,
-        col=1,
-    )
+    # Box for scores
+    if scores.size:
+        ax_scores.boxplot(scores, showmeans=True, tick_labels=["Final Score"])
+    ax_scores.set_ylabel("Final Score")
 
-    # Create a second independent y-axis for runtimes by adding as another trace with different x name
-    fig.add_trace(
-        go.Box(
-            y=rtimes,
-            name="Runtime (s)",
-            boxmean=True,
-            marker_color="#ff7f0e",
-        ),
-        row=1,
-        col=2,
-    )
+    # Box for runtimes (independent axis/scale)
+    if rtimes.size:
+        ax_rtimes.boxplot(rtimes, showmeans=True, tick_labels=["Runtime (s)"])
+    ax_rtimes.set_ylabel("Runtime (seconds)")
 
-    fig.update_layout(
-        title=f"{title_prefix}: Final Score and Runtime",
-        template="plotly_white",
-        showlegend=False,
-        yaxis_title="Final Score",
-        yaxis2_title="Runtime (seconds)",
-    )
+    fig.suptitle(f"{title_prefix}: Final Score and Runtime")
+    fig.tight_layout()
 
-    fig.show()
+    return _finish(fig)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,29 @@
+import os
+
+
+def pytest_addoption(parser):
+    """Add a global flag controlling whether plots are displayed during tests.
+
+    By default the test suite runs fully headless (no windows/browser tabs pop
+    up), which keeps it safe for CI and agentic runs. Pass ``--show-plots`` to
+    display figures interactively instead.
+    """
+    parser.addoption(
+        "--show-plots",
+        action="store_true",
+        default=False,
+        help="Display plots interactively during tests instead of running headless.",
+    )
+
+
+def pytest_configure(config):
+    # Runs after option parsing but before test modules are imported, so setting
+    # the env var and backend here takes effect before ``optimizers.plot`` (or
+    # any direct ``matplotlib.pyplot`` import) is loaded during collection.
+    import matplotlib
+
+    if config.getoption("--show-plots"):
+        os.environ["OPTIMIZERS_NO_SHOW"] = "0"
+    else:
+        os.environ["OPTIMIZERS_NO_SHOW"] = "1"
+        matplotlib.use("Agg")

--- a/tests/test_optimizers.py
+++ b/tests/test_optimizers.py
@@ -1,4 +1,6 @@
 import matplotlib.pyplot as plt
+
+from optimizers.plot import show_plots_enabled
 import numpy as np
 import pytest
 
@@ -273,4 +275,7 @@ def plot_solution_spiral(n_dim: int, points: AF):
     ax.set_ylim(bottom=-0.1, top=1.1)
     plt.title("Solution Distribution")
     plt.grid(True)
-    plt.show()
+    if show_plots_enabled():
+        plt.show()
+    else:
+        plt.close(ax.figure)

--- a/tests/test_plot.py
+++ b/tests/test_plot.py
@@ -1,0 +1,67 @@
+import matplotlib
+import numpy as np
+from matplotlib.figure import Figure
+
+from optimizers.plot import (
+    plot_cities_and_route,
+    plot_convergence,
+    plot_run_statistics,
+    set_show_plots,
+    show_plots_enabled,
+)
+
+
+def test_backend_is_headless():
+    # conftest forces the non-interactive Agg backend for the suite.
+    assert matplotlib.get_backend().lower() == "agg"
+    assert show_plots_enabled() is False
+
+
+def test_plot_convergence_returns_figure_without_showing():
+    fig = plot_convergence(np.array([10.0, 8.0, 7.0, 6.5]))
+    assert isinstance(fig, Figure)
+
+
+def test_plot_convergence_multiple_traces():
+    fig = plot_convergence(
+        [np.array([5.0, 4.0, 3.0]), np.array([9.0, 6.0, 4.0])],
+        trace_names=["A", "B"],
+    )
+    assert isinstance(fig, Figure)
+
+
+def test_plot_cities_and_route_tour():
+    cities = np.array([[0.0, 0.0], [1.0, 0.0], [1.0, 1.0], [0.0, 1.0]])
+    route = np.array([0, 1, 2, 3])
+    fig = plot_cities_and_route(cities, route)
+    assert isinstance(fig, Figure)
+
+
+def test_plot_cities_and_route_2d_segments():
+    cities = np.array([[0.0, 0.0], [1.0, 0.0], [1.0, 1.0], [0.0, 1.0]])
+    mst = np.array([[0, 1], [2, 3]])
+    fig = plot_cities_and_route(cities, mst)
+    assert isinstance(fig, Figure)
+
+
+def test_plot_run_statistics_from_dict():
+    summary = {"scores": [3.0, 2.5, 2.7, 2.6], "runtimes": [1.1, 1.3, 1.2, 1.0]}
+    fig = plot_run_statistics(summary)
+    assert isinstance(fig, Figure)
+
+
+def test_plot_run_statistics_empty_is_safe():
+    # Empty inputs must not raise (matplotlib boxplot rejects empty arrays).
+    fig = plot_run_statistics({"scores": [], "runtimes": []})
+    assert isinstance(fig, Figure)
+
+
+def test_set_show_plots_toggles_flag():
+    original = show_plots_enabled()
+    try:
+        set_show_plots(True)
+        assert show_plots_enabled() is True
+        set_show_plots(False)
+        assert show_plots_enabled() is False
+    finally:
+        set_show_plots(original)


### PR DESCRIPTION
## Operation Offline Plots

Converts all plotting from **plotly** (which opens a browser tab on `show()`) back to **matplotlib/pyplot**, and adds a global switch to disable displaying plots — so tests and agentic runs stay fully offline.

### What changed
- **`src/optimizers/plot/__init__.py`** — reimplemented `plot_convergence`, `plot_cities_and_route`, and `plot_run_statistics` with matplotlib. Each now returns the `Figure` (previously `None`), which makes them testable.
- **Global no-show flag**:
  - `OPTIMIZERS_NO_SHOW` env var (`1/true/yes/on`) selects the non-interactive **Agg** backend *before* pyplot is imported and suppresses `plt.show()` — safe for headless/CI/agentic use.
  - `set_show_plots(bool)` / `show_plots_enabled()` give a runtime toggle without touching the env. Both re-exported from the top-level `optimizers` package.
- **`tests/conftest.py`** — the suite runs headless by default; pass `--show-plots` to display figures interactively.
- **`pyproject.toml`** — `matplotlib>=3.10` promoted to a runtime dependency; `plotly` removed.
- **`tests/test_plot.py`** — new coverage for headless behavior, figure return, empty-input safety, and the toggle. The test-local spiral plot in `test_optimizers.py` now honors the flag too.

### Verification
- `tests/test_plot.py` — 8 passed
- `tests/test_checkpointing.py`, `tests/test_optimizers.py`, `tests/test_combinatorics.py` (the plotting consumers) — all pass, no windows opened, no Agg warnings
- `black` + `flake8` clean
- No remaining `plotly` imports anywhere

🤖 Generated with [Claude Code](https://claude.com/claude-code)