### PR TITLE
chore(lint): ratchet up flake8 + mypy, enforce both in CI

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -18,5 +18,9 @@ jobs:
         run: |
           pip install black
           black --check .
+      - name: Lint with flake8
+        run: flake8 ./src ./tests
+      - name: Type-check with mypy
+        run: MYPYPATH=src mypy -p optimizers
       - name: Run tests
         run: PYTHONPATH=./src pytest tests/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,7 @@ dev = [
     "pytest>=6.0",
     "black>=24.0",
     "matplotlib>=3.10",
+    "mypy>=1.8",
     "flake8",
     "Flake8-pyproject",
     "optuna>=4.3.0",
@@ -53,3 +54,60 @@ max-line-length = 120
 exclude = ".git,__pycache__,build,dist,.eggs,.tox,.venv,venv"
 include = "./src,./tests"
 extend-ignore = ["E203"]
+
+[tool.mypy]
+python_version = "3.10"
+mypy_path = "src"
+ignore_missing_imports = true       # joblib / sklearn / kmodes ship no stubs
+warn_unused_ignores = true          # ratchet: flags an ignore once its error is fixed
+warn_redundant_casts = true
+show_error_codes = true
+
+# --- Ratchet baseline -------------------------------------------------------
+# The modules below still carry numpy dtype-union errors: the AF/AI aliases are
+# unions of float64/32/16 (and int64/32/16), which mypy cannot reconcile with
+# the concrete dtypes the numpy stubs infer. They are silenced *per error-code*
+# so every OTHER class of error — and any brand-new error type — is still caught
+# in these files. In particular `union-attr` stays ON here so genuine None-safety
+# bugs are not masked. Tighten this list down over successive ratchets; the goal
+# is to delete it entirely once the AF/AI aliases are reworked.
+[[tool.mypy.overrides]]
+module = [
+    "optimizers.checkpoint",
+    "optimizers.core.base",
+    "optimizers.combinatorial.base",
+    "optimizers.combinatorial.aco",
+    "optimizers.combinatorial.ga",
+    "optimizers.combinatorial.mtsp",
+    "optimizers.combinatorial.strategy",
+    "optimizers.continuous.aco",
+    "optimizers.continuous.base",
+    "optimizers.continuous.ga",
+    "optimizers.continuous.gd",
+    "optimizers.continuous.pso",
+    "optimizers.continuous.step",
+    "optimizers.continuous.variables",
+    "optimizers.continuous.optimizer_strategy",
+]
+disable_error_code = [
+    "arg-type",
+    "assignment",
+    "index",
+    "list-item",
+    "misc",
+    "operator",
+    "override",
+    "return-value",
+]
+
+# aco_mst additionally has a dtype-union `union-attr` (an int|ndarray branch),
+# so it gets its own block rather than weakening union-attr everywhere else.
+[[tool.mypy.overrides]]
+module = ["optimizers.combinatorial.aco_mst"]
+disable_error_code = [
+    "arg-type",
+    "assignment",
+    "operator",
+    "return-value",
+    "union-attr",
+]

--- a/src/optimizers/combinatorial/aco_mst.py
+++ b/src/optimizers/combinatorial/aco_mst.py
@@ -1,12 +1,10 @@
-from dataclasses import dataclass
 from typing import Optional
 
 import numpy as np
 from joblib import delayed
 
 from .base import CombinatoricsResult, TSPBase, _check_stop_early
-from .strategy import TwoOptTSPConfig, TwoOptTSP
-from ..core.base import IOptimizerConfig, setup_for_generations
+from ..core.base import setup_for_generations
 from ..core.types import AI, AF, F, ab8, i32, i16
 from .aco import AntColonyTSPConfig
 

--- a/src/optimizers/combinatorial/base.py
+++ b/src/optimizers/combinatorial/base.py
@@ -46,13 +46,18 @@ def _check_stop_early(config: IOptimizerConfig, soln_history: list[F]) -> StopRe
 
 
 class TSPBase(ABC):
+    # ``network_routes`` is always populated by ``set_network_routes`` during
+    # __init__ (the None branch asserts city_locations is present), so it is a
+    # non-Optional distance matrix for the lifetime of the solver.
+    city_locations: AF | None
+    network_routes: AF
+
     def __init__(
         self,
         network_routes: AF | None = None,
         city_locations: AF | None = None,
     ):
         self.city_locations = None
-        self.network_routes = None
         self.set_network_routes(network_routes, city_locations)
 
     def set_network_routes(

--- a/src/optimizers/combinatorial/mtsp.py
+++ b/src/optimizers/combinatorial/mtsp.py
@@ -68,7 +68,7 @@ class AntColonyMTSP:
             variables=variables,
             fcn=goal_fcn,
         )
-        result = solver.solve()
+        solver.solve()
 
         raise ValueError("TSP clustering is not yet supported")
 
@@ -81,8 +81,6 @@ class AntColonyMTSP:
             cluster_cities = self.city_locations[cluster, :]
             cluster_config = create_from_dict(self.config.__dict__, AntColonyTSPConfig)
             cluster_config.name = f"{self.config.name}-{cluster_id + 1}"
-            # Not relevant, but for clarity
-            cluster_config.n_clusters = 1
             tsp_solve = AntColonyTSP(cluster_config, city_locations=cluster_cities)
             cluster_result = tsp_solve.solve()
             # Map cluster indices back to original indices
@@ -125,7 +123,7 @@ class AntColonyMTSP:
                 n_clusters=self.config.n_clusters, assign_labels="discretize"
             )
             cluster_labels = sc.fit_predict(self.city_locations)
-            clusters: list[list[int]] = [[] for _ in range(self.config.n_clusters)]
+            clusters = [[] for _ in range(self.config.n_clusters)]
             for i, label in enumerate(cluster_labels):
                 clusters[label].append(i)
             return clusters

--- a/src/optimizers/combinatorial/strategy.py
+++ b/src/optimizers/combinatorial/strategy.py
@@ -1,4 +1,3 @@
-import heapq
 from dataclasses import dataclass
 from typing import Optional
 
@@ -229,7 +228,7 @@ class TwoOptTSP(TSPBase):
         )
 
     def setup_local_search(self) -> tuple[int, AI]:
-        if self.initial_route is None or self.initial_value == None:
+        if self.initial_route is None or self.initial_value is None:
             # Use the nearest neighbor
             nn_config = NearestNeighborTSPConfig(
                 back_to_start=self.config.back_to_start, name=self.config.name
@@ -242,6 +241,7 @@ class TwoOptTSP(TSPBase):
             solution = nn_solver.solve()
             self.initial_route = solution.optimal_path
             self.initial_value = solution.optimal_value
+        assert self.initial_route is not None
         new_route = self.initial_route.copy()
         N = self.network_routes.shape[0]
         return N, new_route
@@ -383,6 +383,7 @@ class ConvexHullTSP(TSPBase):
                 t += 2 * np.pi
             return t
 
+        assert self.city_locations is not None  # ConvexHull requires coordinates
         restarted = False
         while True:
             # Find the point which is CCW from this point by the least amount.

--- a/src/optimizers/combinatorial/strategy.py
+++ b/src/optimizers/combinatorial/strategy.py
@@ -12,7 +12,10 @@ from ..core.types import AI, F, AF
 # (see CYTHON_ANALYSIS.md); if it isn't compiled, the numba kernels are used, so
 # a plain source checkout still runs without a build step.
 try:
-    from . import _tsp_cython
+    # Compiled extension: no source/stub for mypy to read (built ahead-of-time),
+    # so the submodule attribute is invisible to static analysis whether or not
+    # the .so is present — silence just this optional-backend import.
+    from . import _tsp_cython  # type: ignore[attr-defined]
 
     HAS_CYTHON = True
 except ImportError:  # pragma: no cover - exercised only in unbuilt checkouts

--- a/src/optimizers/continuous/aco.py
+++ b/src/optimizers/continuous/aco.py
@@ -1,6 +1,5 @@
 from dataclasses import dataclass
 
-import joblib
 import numpy as np
 
 from .local import apply_local_optimization
@@ -8,7 +7,6 @@ from ..core.base import (
     IOptimizerConfig,
     OptimizerResult,
     OptimizerRun,
-    LocalOptimType,
     GoalFcn,
     InputArguments,
 )
@@ -17,7 +15,6 @@ from ..core.parallel import GenerationRunner
 from ..core.types import af64
 from ..solution_deck import (
     SolutionDeck,
-    WrappedGoalFcn,
 )
 from ..core.random import rng as global_rng
 

--- a/src/optimizers/continuous/base.py
+++ b/src/optimizers/continuous/base.py
@@ -5,7 +5,7 @@ import numpy as np
 import time
 import uuid
 import inspect
-from typing import Optional, Callable, Any, Literal
+from typing import Optional, Any
 
 from ..core import InputVariables
 from ..core.base import (
@@ -112,7 +112,7 @@ class IOptimizer(abc.ABC):
                     return _f(x, _ap.current())
                 return _f(x)
 
-            return __wrapped  # type: ignore[return-value]
+            return __wrapped
 
         # Wrap the goal function and constraint functions
         self.wrapped_fcn: WrappedGoalFcn = _wrap_goal(fcn)

--- a/src/optimizers/continuous/ga.py
+++ b/src/optimizers/continuous/ga.py
@@ -1,6 +1,5 @@
 from dataclasses import dataclass
 
-import joblib
 import numpy as np
 from numpy.random import Generator
 
@@ -10,7 +9,6 @@ from ..core.base import (
     OptimizerResult,
     IOptimizerConfig,
     OptimizerRun,
-    LocalOptimType,
     GoalFcn,
     InputArguments,
 )
@@ -25,7 +23,6 @@ from .base import IOptimizer
 
 from ..solution_deck import (
     SolutionDeck,
-    WrappedGoalFcn,
 )
 
 

--- a/src/optimizers/continuous/local.py
+++ b/src/optimizers/continuous/local.py
@@ -3,7 +3,7 @@ from ..core.base import LocalOptimType, ensure_literal_choice
 from ..solution_deck import WrappedGoalFcn
 from .variables import InputVariable, InputDiscreteVariable
 from ..core.types import AF, F
-from typing import get_args, Optional
+from typing import get_args
 
 
 def apply_local_optimization(

--- a/src/optimizers/continuous/optimizer_strategy.py
+++ b/src/optimizers/continuous/optimizer_strategy.py
@@ -188,6 +188,7 @@ class GroupedVariableOptimizer(IOptimizer):
         # TODO - Pass in previous best solution deck
         # TODO - Support for check-pointing!
         default_values = [var.initial_value for var in self.variables]
+        assert self.config.groups is not None  # validated in __init__
         for cur_round in range(self.config.num_rounds):
             for group in self.config.groups:
                 group_vars = [v for v in self.variables if v.name in group.variables]
@@ -198,7 +199,7 @@ class GroupedVariableOptimizer(IOptimizer):
                     return self.wrapped_fcn(y)
 
                 config = config_to_type(self.config, group.optimizer_type)
-                optimizer: IOptimizer
+                optim: IOptimizer
                 if group.optimizer_type == "aco":
                     optim = AntColonyOptimizer(config, new_fcn, group_vars)
                 elif group.optimizer_type == "pso":

--- a/src/optimizers/continuous/pso.py
+++ b/src/optimizers/continuous/pso.py
@@ -1,6 +1,5 @@
 from dataclasses import dataclass
 
-import joblib
 import numpy as np
 
 from ..core.base import (
@@ -10,7 +9,6 @@ from ..core.base import (
 )
 from ..core.types import AF, F
 from ..solution_deck import (
-    WrappedGoalFcn,
     InputVariables,
     SolutionDeck,
 )

--- a/src/optimizers/core/parallel.py
+++ b/src/optimizers/core/parallel.py
@@ -117,6 +117,7 @@ class GenerationRunner:
         """
         n = self.n_jobs if count is None else count
         if self.prefer == "processes":
+            assert self._executor is not None
             futures = [
                 self._executor.submit(
                     _call_with_fixed, worker_fn, self._token, varying_args
@@ -124,6 +125,7 @@ class GenerationRunner:
                 for _ in range(n)
             ]
             return [f.result() for f in futures]
+        assert self._parallel is not None
         return self._parallel(
             joblib.delayed(worker_fn)(self._fixed, *varying_args) for _ in range(n)
         )

--- a/src/optimizers/core/random.py
+++ b/src/optimizers/core/random.py
@@ -44,7 +44,6 @@ def rng() -> np.random.Generator:
     fresh entropy so default behavior remains non-deterministic unless the
     caller opted in via set_seed(...).
     """
-    global _global_rng
     if _global_rng is None:
         set_seed(None)
     assert _global_rng is not None

--- a/src/optimizers/core/types.py
+++ b/src/optimizers/core/types.py
@@ -23,5 +23,5 @@ T = typing.TypeVar("T")
 AF = typing.Union[af64, af32, af16]
 AI = typing.Union[ai64, ai32, ai16]
 F = typing.Union[f64, f32, f16]
-I = typing.Union[i64, i32, i16]
+I = typing.Union[i64, i32, i16]  # noqa: E741
 B = typing.Union[b8]

--- a/src/optimizers/core/variables.py
+++ b/src/optimizers/core/variables.py
@@ -1,5 +1,4 @@
 from abc import ABC, abstractmethod
-from dataclasses import dataclass
 
 import numpy as np
 from numpy.random import Generator

--- a/src/optimizers/solution_deck.py
+++ b/src/optimizers/solution_deck.py
@@ -7,7 +7,7 @@ from kmodes.kmodes import KModes
 
 from .core.base import ensure_literal_choice, WrappedGoalFcn
 from .core.random import get_seed
-from .core.types import f64, af64, ab8, b8, i64
+from .core.types import f64, af64, ab8, b8
 from .core.variables import InputVariables
 
 # Some type hinting
@@ -238,7 +238,7 @@ def lloyds_algorithm_points(n: int, k: int, n_steps: int = 10) -> af64:
     points = np.sort(np.random.random(size=(n, k)), axis=0)
 
     for step in range(n_steps):
-        labels = kmeans.fit_predict(points)
+        kmeans.fit_predict(points)
         centers = kmeans.cluster_centers_
         centers = np.sort(centers, axis=0)
         # Early stopping if converged
@@ -283,8 +283,7 @@ def fibonacci_sphere_points(n: int, k: int) -> af64:
         points[:, j] *= np.cos(theta[:, j])
         points[:, (j + 1) :] *= np.sin(theta[:, j])[:, np.newaxis]
 
-    r = np.logspace(-1.0, 0.0, n)
-    # points = points * r[:, np.newaxis]
+    # points = points * np.logspace(-1.0, 0.0, n)[:, np.newaxis]
 
     # Inscribe the unit-ball in the unit hyper-cube
     points /= np.max(np.linalg.norm(points, axis=1))
@@ -308,13 +307,14 @@ def inv_elliptic2(s: f64, m: f64) -> f64:
             alpha_min = alpha_mid
         else:
             alpha_max = alpha_mid
-    return alpha_mid
+    return f64(alpha_mid)
 
 
 @lru_cache(maxsize=16)
 def spiral_points(n: int, k: int) -> af64:
     """
-    Generates N points in a k-dimensional space using rotation matrices. Source: https://www.fujipress.jp/jaciii/jc/jacii001500081116/
+    Generates N points in a k-dimensional space using rotation matrices.
+    Source: https://www.fujipress.jp/jaciii/jc/jacii001500081116/
 
     Args:
         n (int): Number of points.

--- a/tests/test_runtime_args.py
+++ b/tests/test_runtime_args.py
@@ -1,4 +1,3 @@
-import time
 import numpy as np
 import pytest
 
@@ -37,7 +36,6 @@ def test_phase_literal_definition():
 def test_metadata_injection_into_goal_and_constraints(tiny_ga_cfg):
     # Record snapshots of metadata seen inside the functions
     seen_goal = []
-    seen_cons = []
 
     user_args = {"note": "hello", "generation": -123}  # collision: metadata should win
 


### PR DESCRIPTION
## Lint ratchet

Brings the tree to **zero flake8 violations**, adds a **mypy** configuration with a documented per-module baseline for the hard numpy dtype-union errors, and **enforces both in PR CI**. Latest `main` (matplotlib plotting + QD/MAP-Elites, #80–#82) is merged in.

### flake8: 28 → 0
- Removed unused imports/locals across `continuous/*`, `combinatorial/*`, `core/*`, tests.
- `== None` → `is None` (`strategy.py`); `# noqa: E741` on the intentional `I` scalar-union alias (part of the `AF/AI/F/I/B` type vocabulary); wrapped an over-long docstring line.

### mypy: new `[tool.mypy]` config
- `ignore_missing_imports` (joblib/sklearn/kmodes ship no stubs), `warn_unused_ignores` (a fixed error's `# type: ignore` gets flagged → auto-ratchet), `warn_redundant_casts`, `show_error_codes`.
- **Genuine bugs fixed:**
  - `mtsp.py` set a nonexistent `n_clusters` attribute on `AntColonyTSPConfig` (the comment even said "not relevant"); removed.
  - Duplicate `clusters` annotation (`no-redef`); redundant `# type: ignore` in `continuous/base.py`.
- **None-safety** narrowed via asserts backed by existing invariants (not blanket-silenced): `GenerationRunner` executor/parallel, `TSPBase.network_routes` (now typed non-Optional `AF`), `TwoOptTSP.initial_route`, `ConvexHullTSP.city_locations`, `GroupedVariableOptimizer.config.groups` (already validated in `__init__`).
  - `inv_elliptic2` now returns `f64`.
- **Baseline:** the remaining numpy dtype-union errors (the `AF`/`AI` aliases are unions of float64/32/16 and int64/32/16, which mypy can't reconcile with the concrete numpy stub dtypes) are silenced **per module, per error-code** via `disable_error_code`. Every other error class — and any brand-new error type — is still caught in those files, and `union-attr` stays enabled except where it's dtype-driven. The intent is to shrink this list in future ratchets and delete it once `AF/AI` are reworked.

### CI (`pr.yml`)
Added `flake8 ./src ./tests` and `MYPYPATH=src mypy -p optimizers` steps, so the ratchet can't regress.

### Verification
- `flake8 ./src ./tests` → clean
- `mypy -p optimizers` → `Success: no issues found in 33 source files`
- `black --check .` → clean
- `pytest tests/` → **47 passed** (headless via the merged conftest)

🤖 Generated with [Claude Code](https://claude.com/claude-code)