### PR TITLE
fix(types): mypy dtype error in SolutionDeck.from_dict

### DIFF
--- a/src/optimizers/solution_deck.py
+++ b/src/optimizers/solution_deck.py
@@ -275,7 +275,9 @@ class SolutionDeck:
     def from_dict(cls, data: dict[str, Any]) -> "SolutionDeck":
         archive_size = int(data.get("archive_size", 0))
         num_vars = int(data.get("num_vars", 0))
-        dtype = np.dtype(data.get("dtype", str(np.float64)))
+        # ``.type`` yields the scalar class (e.g. np.float64) the constructor
+        # expects (type[np.generic]), not a dtype instance.
+        dtype = np.dtype(data.get("dtype", str(np.float64))).type
         deck = cls(archive_size=archive_size, num_vars=num_vars, dtype=dtype)
         # Overwrite with stored arrays (may be larger due to appends)
         deck.solution_archive = np.array(data["solution_archive"], dtype=dtype)


### PR DESCRIPTION
Main is currently red under the mypy gate enabled by #88: `SolutionDeck.from_dict` passes a `np.dtype` instance where the constructor's `dtype` parameter is typed `type[np.generic]`. This slipped in because the QD PRs (#82–#84) modified `solution_deck.py` while CI was still black+pytest only, and #88's branch predated those changes.

Fix: take `.type` off the parsed dtype to hand mypy the scalar class (e.g. `np.float64`). Runtime is unchanged — `np.empty`/`np.array` accept both a dtype instance and a scalar type.

Verified locally: `mypy -p optimizers` clean (34 files), flake8 clean, black clean, deck roundtrip tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)