### PR TITLE
perf(ci): add global --fast flag to cap optimizer workloads in CI

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -31,4 +31,7 @@ jobs:
       - name: Type-check with mypy
         run: MYPYPATH=src mypy -p optimizers
       - name: Run tests
-        run: PYTHONPATH=./src pytest tests/
+        # --fast caps optimizer workloads (generations/population) so the
+        # pipeline finishes in a reasonable timeline; correctness assertions
+        # still run in full. Drop the flag to run the full-fidelity workloads.
+        run: PYTHONPATH=./src pytest tests/ --fast

--- a/src/optimizers/core/base.py
+++ b/src/optimizers/core/base.py
@@ -1,3 +1,4 @@
+import os
 from typing import Literal, Optional, TypeVar, get_args, Callable, Union, Any
 from dataclasses import dataclass, fields
 import numpy as np
@@ -5,6 +6,28 @@ from joblib import cpu_count, Parallel
 from tqdm import trange, tqdm
 
 from .types import AF, F
+
+_TRUTHY = {"1", "true", "yes", "on"}
+
+# Fast-tests caps. Applied to every optimizer config when ``OPTIMIZERS_FAST`` is
+# set, so the CI/agentic pipeline finishes in a reasonable timeline instead of
+# running the full-fidelity workloads. The caps are deliberately at (not below)
+# the values the correctness-threshold tests rely on (e.g. the map-elites
+# coverage checks run 15 generations over a population of 40), so only the heavy
+# long-running configs are shrunk while every assertion keeps holding.
+_FAST_MAX_GENERATIONS = 15
+_FAST_MAX_POPULATION = 40
+
+
+def fast_tests_enabled() -> bool:
+    """Whether the ``OPTIMIZERS_FAST`` environment variable caps optimizer workloads.
+
+    This is the runtime analogue of ``OPTIMIZERS_NO_SHOW`` (which forces headless
+    plotting): a single global switch that keeps the test/CI pipeline fast. It is
+    off by default, so ordinary runs use the full configured workloads.
+    """
+    return os.environ.get("OPTIMIZERS_FAST", "").strip().lower() in _TRUTHY
+
 
 JoblibPrefer = Literal["threads", "processes"]
 StopReason = Literal["none", "target_score", "no_improvement", "max_iterations"]
@@ -145,6 +168,20 @@ class IOptimizerConfig:
     """Iso+LineDD isotropic std-dev, as a fraction of each variable's domain."""
     line_sigma: float = 0.2
     """Iso+LineDD directional (line) std-dev (dimensionless)."""
+
+    def __post_init__(self) -> None:
+        # When fast mode is on, cap the dominant runtime drivers so the pipeline
+        # stays quick. ``min`` never *raises* a value, so small configs (e.g. the
+        # map-elites tests) are left untouched. Forcing the joblib backend to
+        # threads avoids re-spawning worker *processes* every generation (which
+        # re-imports numpy/numba/matplotlib and dominates the wall-clock — ~8x
+        # slower here); the per-individual computation, and therefore every
+        # assertion, is identical either way. Subclasses that add their own
+        # ``__post_init__`` should call ``super().__post_init__()``.
+        if fast_tests_enabled():
+            self.num_generations = min(self.num_generations, _FAST_MAX_GENERATIONS)
+            self.population_size = min(self.population_size, _FAST_MAX_POPULATION)
+            self.joblib_prefer = "threads"
 
 
 @dataclass

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -14,12 +14,22 @@ def pytest_addoption(parser):
         default=False,
         help="Display plots interactively during tests instead of running headless.",
     )
+    parser.addoption(
+        "--fast",
+        action="store_true",
+        default=False,
+        help=(
+            "Cap optimizer workloads (generations/population) so the suite runs "
+            "in a reasonable timeline. Used by CI; results still validate."
+        ),
+    )
 
 
 def pytest_configure(config):
     # Runs after option parsing but before test modules are imported, so setting
-    # the env var and backend here takes effect before ``optimizers.plot`` (or
-    # any direct ``matplotlib.pyplot`` import) is loaded during collection.
+    # the env vars and backend here takes effect before ``optimizers.plot`` (or
+    # any direct ``matplotlib.pyplot`` import) is loaded during collection, and
+    # before any optimizer config is constructed.
     import matplotlib
 
     if config.getoption("--show-plots"):
@@ -27,3 +37,8 @@ def pytest_configure(config):
     else:
         os.environ["OPTIMIZERS_NO_SHOW"] = "1"
         matplotlib.use("Agg")
+
+    # Global fast switch, analogous to the headless-plot switch above. Off by
+    # default so local runs keep full fidelity; CI opts in with ``--fast``.
+    if config.getoption("--fast"):
+        os.environ["OPTIMIZERS_FAST"] = "1"


### PR DESCRIPTION
CI test runtime was ~205s (3:25), dominated by four heavy optimizer
tests (test_aco_tsp 76s, test_aco_mst 74s, test_aco 19s, test_mtsp 17s)
that run large populations over many generations, several with
process-based joblib backends that re-spawn workers every generation.

Add a global OPTIMIZERS_FAST switch — the runtime analogue of the
existing OPTIMIZERS_NO_SHOW headless-plot flag — exposed as a --fast
pytest option and enabled in the PR workflow. When set,
IOptimizerConfig caps num_generations (<=15) and population_size (<=40)
and forces the joblib backend to threads (avoiding ~8x process-spawn
overhead). Caps sit at/above the values the correctness-threshold tests
rely on, so every assertion still holds; the switch is off by default so
ordinary local runs keep full fidelity.

Suite drops from ~205s to ~26s (all 83 tests still pass).

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_014c7zn4MNnWBRHiiXfVYwie