### PR TITLE
fix(tsp): make local_optimize honor back_to_start (#47)

### DIFF
--- a/src/optimizers/combinatorial/aco.py
+++ b/src/optimizers/combinatorial/aco.py
@@ -120,8 +120,12 @@ class AntColonyTSP(TSPBase):
                     break
 
         if self.config.local_optimize:
-            # TODO - Better parameters?
-            two_opt_config = TwoOptTSPConfig()
+            # Propagate back_to_start so the 2-opt refinement optimizes (and
+            # reports) for the same open/closed objective as the ACO run; a bare
+            # TwoOptTSPConfig() would silently force back_to_start=True.
+            two_opt_config = TwoOptTSPConfig(
+                back_to_start=self.config.back_to_start, name=self.config.name
+            )
             two_opt_optimize = TwoOptTSP(
                 two_opt_config,
                 initial_route=optimal_city_order,

--- a/src/optimizers/combinatorial/ga.py
+++ b/src/optimizers/combinatorial/ga.py
@@ -118,8 +118,12 @@ class GeneticAlgorithmTSP(TSPBase):
                     break
 
         if self.config.local_optimize:
-            # TODO - Better parameters?
-            two_opt_config = TwoOptTSPConfig()
+            # Propagate back_to_start so the 2-opt refinement optimizes (and
+            # reports) for the same open/closed objective as the GA run; a bare
+            # TwoOptTSPConfig() would silently force back_to_start=True.
+            two_opt_config = TwoOptTSPConfig(
+                back_to_start=self.config.back_to_start, name=self.config.name
+            )
             two_opt_optimize = TwoOptTSP(
                 two_opt_config,
                 initial_route=genome[0, :],

--- a/src/optimizers/combinatorial/strategy.py
+++ b/src/optimizers/combinatorial/strategy.py
@@ -39,6 +39,25 @@ class TwoOptTSPConfig(IOptimizerConfig):
     it has been built (falls back to numba otherwise). Results are identical."""
 
 
+def _depot_first_tour(route: AI, n: int) -> AI:
+    """Reduce a kernel-mutated route to the ``n`` distinct cities, depot-first.
+
+    2-opt's wrap-edge sweep (``start=-1`` when ``back_to_start``) can reverse a
+    segment beginning at index 0, relocating the depot (city 0) into the middle.
+    That is a cost-preserving rotation of the cyclic tour, but ``check_path_distance``
+    closes the loop back to city 0 *specifically*, so a non-depot-first route makes
+    it add a spurious closing edge and over-report the length. Drop any appended
+    depot copy (``route[:n]``) and rotate city 0 to the front. Returns the *open*
+    depot-first tour: callers pass it to ``check_path_distance`` (which adds the
+    return leg for ``back_to_start``) and append the depot themselves for output.
+    """
+    tour = np.asarray(route[:n])
+    zero_pos = int(np.flatnonzero(tour == 0)[0])
+    if zero_pos != 0:
+        tour = np.roll(tour, -zero_pos)
+    return np.ascontiguousarray(tour)
+
+
 def _swap_segment(ij: int, jk: int, new_route: AI) -> AI:
     ij += 1
     while ij < jk:
@@ -404,15 +423,20 @@ class TwoOptTSP(TSPBase):
                 )
             )
 
-        history = [
-            check_path_distance(
-                self.network_routes, new_route, self.config.back_to_start
-            )
-        ]
+        # 2-opt can rotate the depot off index 0; restore depot-first order so
+        # check_path_distance measures the true (cyclic) tour length. Measure on
+        # the open tour, then append the depot for the returned closed path (the
+        # NearestNeighbor/LinKernighan/ConvexHull convention for back_to_start).
+        tour = _depot_first_tour(new_route, N)
+        value = check_path_distance(
+            self.network_routes, tour, self.config.back_to_start
+        )
+        out = np.append(tour, tour[0]) if self.config.back_to_start else tour
+        history = [value]
 
         return CombinatoricsResult(
-            optimal_path=np.array(new_route),
-            optimal_value=history[-1],
+            optimal_path=np.array(out),
+            optimal_value=value,
             value_history=np.array(history),
             stop_reason="no_improvement" if no_moves else "max_iterations",
         )
@@ -480,15 +504,18 @@ class ThreeOptTSP(TwoOptTSP):
                 )
             )
 
-        history = [
-            check_path_distance(
-                self.network_routes, new_route, self.config.back_to_start
-            )
-        ]
+        # 3-opt never writes index 0, so the depot rotation is a no-op here; keep
+        # the shared normalization for one depot-first postcondition across both.
+        tour = _depot_first_tour(new_route, N)
+        value = check_path_distance(
+            self.network_routes, tour, self.config.back_to_start
+        )
+        out = np.append(tour, tour[0]) if self.config.back_to_start else tour
+        history = [value]
 
         return CombinatoricsResult(
-            optimal_path=np.array(new_route),
-            optimal_value=history[-1],
+            optimal_path=np.array(out),
+            optimal_value=value,
             value_history=np.array(history),
             stop_reason="no_improvement" if no_moves else "max_iterations",
         )

--- a/tests/test_combinatorics.py
+++ b/tests/test_combinatorics.py
@@ -1,4 +1,5 @@
 import numpy as np
+import pytest
 from sklearn.metrics import pairwise_distances
 
 from optimizers.combinatorial.aco import (
@@ -7,6 +8,7 @@ from optimizers.combinatorial.aco import (
 )
 from optimizers.combinatorial.ga import GeneticAlgorithmTSPConfig, GeneticAlgorithmTSP
 from optimizers.combinatorial.mtsp import AntColonyMTSPConfig, AntColonyMTSP
+from optimizers.combinatorial.base import check_path_distance
 from optimizers.combinatorial.strategy import (
     NearestNeighborTSPConfig,
     NearestNeighborTSP,
@@ -174,6 +176,68 @@ def test_nn_tsp():
         all_cities,
         [result.optimal_path, result2.optimal_path, result3.optimal_path],
     )
+
+
+@pytest.mark.parametrize("back_to_start", [True, False])
+def test_ga_local_optimize_respects_back_to_start(back_to_start):
+    # Issue #47: local_optimize must run the 2-opt refinement with the SAME
+    # open/closed objective as the GA itself. A regression here silently forces
+    # a closed loop, so the reported value stops matching the tour that is
+    # returned (and, for back_to_start=False, can be worse than pre-refinement).
+    np.random.seed(0)
+    all_cities = circle_random_clusters()
+    distances: AF = pairwise_distances(all_cities)
+    config = GeneticAlgorithmTSPConfig(
+        name="ga local-opt",
+        num_generations=N_GENERATIONS,
+        population_size=N_ANTS,
+        stop_after_iterations=5,
+        joblib_prefer="threads",
+        back_to_start=back_to_start,
+        local_optimize=True,
+    )
+    optimizer = GeneticAlgorithmTSP(
+        config, network_routes=distances, city_locations=all_cities
+    )
+    result = optimizer.solve()
+
+    path = np.asarray(result.optimal_path)
+    # Closed tours return depot-first AND depot-last (the return leg); the open
+    # form omits the return leg. Strip it before checking the city set.
+    cities = path[:-1] if back_to_start else path
+    assert sorted(cities.tolist()) == list(range(distances.shape[0]))
+    assert path[0] == 0
+    # The reported value is measured with the run's own back_to_start setting.
+    expected = check_path_distance(distances, path, back_to_start)
+    assert np.isclose(result.optimal_value, expected)
+
+
+@pytest.mark.parametrize("back_to_start", [True, False])
+def test_aco_local_optimize_respects_back_to_start(back_to_start):
+    # Issue #47 companion for the ant-colony path (which MTSP delegates to).
+    np.random.seed(0)
+    all_cities = circle_random_clusters()
+    distances: AF = pairwise_distances(all_cities)
+    config = AntColonyTSPConfig(
+        name="aco local-opt",
+        num_generations=N_GENERATIONS,
+        population_size=N_ANTS,
+        stop_after_iterations=5,
+        joblib_prefer="threads",
+        back_to_start=back_to_start,
+        local_optimize=True,
+    )
+    optimizer = AntColonyTSP(
+        config, network_routes=distances, city_locations=all_cities
+    )
+    result = optimizer.solve()
+
+    path = np.asarray(result.optimal_path)
+    cities = path[:-1] if back_to_start else path
+    assert sorted(cities.tolist()) == list(range(distances.shape[0]))
+    assert path[0] == 0
+    expected = check_path_distance(distances, path, back_to_start)
+    assert np.isclose(result.optimal_value, expected)
 
 
 def test_convex_hull_tsp():


### PR DESCRIPTION
Closes #47.

## What #47 asked
Confirm `local_optimize` and `back_to_start` work together in combinatorics. They did **not** — this PR confirms it with tests and fixes two bugs found along the way.

## Bug 1 — `back_to_start` was dropped
`GeneticAlgorithmTSP` and `AntColonyTSP` built a bare `TwoOptTSPConfig()` for the `local_optimize` refinement, hard-coding `back_to_start=True`. With `back_to_start=False` the 2-opt step optimized and reported a **closed** tour, silently making results *worse* than the pre-refinement open path:

```
back_to_start=False: reported=37.81  (open path was 35.1 before refinement, true open=29.9)
```

## Bug 2 — depot relocation mis-measured closed tours
Fixing bug 1 surfaced a latent issue: 2-opt's wrap-edge sweep (`start=-1`) can reverse a segment beginning at index 0, relocating the depot (city 0) into the middle. `check_path_distance` closes the loop back to city 0 *specifically*, so a non-depot-first route adds a spurious closing edge and over-reports the length — exactly the bare length-N permutations GA/ACO feed in.

```
returned path: [7, 2, 0, 1, 8, 5, 4, 3, 9, 6]   # depot no longer first
reported value : 28.38     true cycle len : 27.10   # over-reported
```

## Fix
- **`ga.py` / `aco.py`**: propagate `back_to_start` (and `name`) into the 2-opt config so the refinement shares the run's open/closed objective.
- **`strategy.py`**: add `_depot_first_tour`; normalize `TwoOptTSP`/`ThreeOptTSP` output to depot-first, measure the value on the *open* tour (avoids a double-closed edge, and avoids the GA/ACO `-1` diagonal poisoning `distances[0,0]`), and append the depot for the returned closed path — matching the NearestNeighbor / LinKernighan / ConvexHull convention.
- **tests**: parametrized GA + ACO regression tests asserting the reported value matches `check_path_distance` under the run's own `back_to_start`, and that the returned path is a valid depot-first tour.

## Verification
- `pytest --fast` full suite: **118 passed**.
- `flake8 ./src ./tests`: clean.
- `mypy`: no new errors (the 3 reported are pre-existing untyped numba kernels, unchanged by this PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K3NA13nwmvgbzUyx8oN9KP