### PR TITLE
feat(runtime): make eval_count a true global count across workers

### DIFF
--- a/src/optimizers/continuous/aco.py
+++ b/src/optimizers/continuous/aco.py
@@ -61,7 +61,9 @@ def run_ants(
             ant_solutions[ant] = new_solution
             ant_values[ant] = new_value
         return OptimizerRun(
-            population_values=ant_values, population_solutions=ant_solutions
+            population_values=ant_values,
+            population_solutions=ant_solutions,
+            eval_count=arg_provider.eval_delta,
         )
 
     # Each ant picks a single base solution from the archive via the rank CDF
@@ -91,7 +93,9 @@ def run_ants(
         ant_solutions[ant] = new_solution
         ant_values[ant] = new_value
     return OptimizerRun(
-        population_values=ant_values, population_solutions=ant_solutions
+        population_values=ant_values,
+        population_solutions=ant_solutions,
+        eval_count=arg_provider.eval_delta,
     )
 
 

--- a/src/optimizers/continuous/base.py
+++ b/src/optimizers/continuous/base.py
@@ -36,23 +36,52 @@ class _ArgProvider:
 
     This object is intentionally lightweight and picklable so wrapped callables
     can be serialized for parallel workers while still carrying the current metadata.
+
+    Evaluation counting is a **true global count** across the whole run — the
+    number the goal function reads as ``eval_count`` reflects every evaluation the
+    run has done so far, not a per-worker tally. Two fields make this work across
+    both parallel backends:
+
+    * ``eval_base`` — evaluations completed *before* the current counting context
+      (previous generations, plus the parent's initialization pass).
+    * ``_local`` — evaluations since the last :meth:`reset_local`.
+
+    The value exposed to the goal function is always ``eval_base + _local``. Under
+    the ``threads`` backend workers share the parent's provider, so ``_local``
+    simply accumulates globally. Under ``processes`` each worker holds an
+    independent copy, so the parent ships the authoritative ``eval_base`` each
+    generation (:meth:`reset_local`), the worker counts its own evaluations up
+    from it, and the parent folds the per-worker deltas back in (:meth:`commit`) —
+    see ``IOptimizer.live_meta`` / ``sync_worker_meta`` /
+    ``IOptimizer._accumulate_eval_count``.
     """
 
     def __init__(self, base_args: Optional[InputArguments] = None):
         self.base_args: InputArguments = dict(base_args or {})
         self.meta: InputArguments = {}
-        self._eval_count: int = 0
+        # Evaluations done before the current counting context, and within it.
+        self.eval_base: int = 0
+        self._local: int = 0
 
     def current(self) -> InputArguments:
         # merge without mutating user-provided dicts
         merged = {**self.base_args, **self.meta}
         return merged
 
+    @property
+    def eval_count(self) -> int:
+        """Global running evaluation count (``eval_base + _local``)."""
+        return self.eval_base + self._local
+
+    @property
+    def eval_delta(self) -> int:
+        """Evaluations in the current context (this generation, per worker)."""
+        return self._local
+
     def bump_eval(self) -> None:
-        # local to the process where the function executes
-        self._eval_count += 1
+        self._local += 1
         now = time.time()
-        self.meta["eval_count"] = self._eval_count
+        self.meta["eval_count"] = self.eval_base + self._local
         self.meta["now"] = now
         # Elapsed seconds since run start
         start = self.meta.get("start_time", now)
@@ -60,6 +89,26 @@ class _ArgProvider:
             self.meta["elapsed_time"] = float(now - start)
         except Exception:
             self.meta["elapsed_time"] = 0.0
+
+    def reset_local(self, base: int) -> None:
+        """Begin a fresh counting context from ``base`` (process-worker copies).
+
+        Called on each worker at the start of a generation so its evaluations are
+        offset by the authoritative global base shipped from the parent.
+        """
+        self.eval_base = int(base)
+        self._local = 0
+        self.meta["eval_count"] = self.eval_base
+
+    def commit(self, delta: int) -> None:
+        """Fold ``delta`` completed evaluations into the global base (parent side).
+
+        Used to (a) close out the parent's initialization pass and (b) absorb the
+        summed per-worker deltas after each generation under the processes backend.
+        """
+        self.eval_base += int(delta)
+        self._local = 0
+        self.meta["eval_count"] = self.eval_base
 
 
 class IOptimizer(abc.ABC):
@@ -206,7 +255,19 @@ class IOptimizer(abc.ABC):
         fields need to be re-synced to worker processes each generation.
         """
         meta = self._arg_provider.meta
-        return {"generation": meta.get("generation"), "phase": meta.get("phase")}
+        live: InputArguments = {
+            "generation": meta.get("generation"),
+            "phase": meta.get("phase"),
+        }
+        if self.config.joblib_prefer == "processes":
+            # Each process worker holds an independent copy of the arg provider,
+            # so hand it the authoritative global evaluation base to count this
+            # generation up from; the per-worker deltas are folded back in on the
+            # parent (see ``_accumulate_eval_count``). Under threads the workers
+            # share the parent's provider, whose counter is already global, so no
+            # base is shipped and no reset happens.
+            live["_eval_base"] = self._arg_provider.eval_count
+        return live
 
     def _set_phase(self, phase: Phase) -> None:
         # Validate at runtime for extra safety in non-type-checked contexts
@@ -241,6 +302,12 @@ class IOptimizer(abc.ABC):
             self.soln_deck.set_all_outputs(
                 self._evaluate_outputs(self.soln_deck.solution_archive)
             )
+
+        # The initialization pass above evaluated the goal function in the parent
+        # process; fold those evaluations into the global base so the first
+        # generation's ``eval_count`` continues from them (and process workers are
+        # shipped the correct starting base). See ``_ArgProvider``.
+        self._arg_provider.commit(self._arg_provider.eval_delta)
 
         # Add the progress bar
         generation_pbar, individuals_per_job, n_jobs, parallel = setup_for_generations(
@@ -303,11 +370,26 @@ class IOptimizer(abc.ABC):
             report.hypervolume = hypervolume(objs, ref)
         return report
 
+    def _accumulate_eval_count(self, job_output: list[OptimizerRun]) -> None:
+        """Fold this generation's per-worker evaluation deltas into the global count.
+
+        Only the ``processes`` backend needs this: each worker counted its own
+        evaluations from the shipped global base, so the parent sums the deltas
+        reported on each ``OptimizerRun`` and advances the authoritative base.
+        Under ``threads`` the workers share the parent's provider, whose counter is
+        already global, so there is nothing to fold (doing so would double-count).
+        """
+        if self.config.joblib_prefer != "processes":
+            return
+        delta = sum(int(getattr(o, "eval_count", 0) or 0) for o in job_output)
+        self._arg_provider.commit(delta)
+
     def update_solution_deck(
         self, generation_pbar: tqdm.tqdm, job_output: list[OptimizerRun]
     ) -> None:
         if not job_output:
             return
+        self._accumulate_eval_count(job_output)
         # Merge all worker outputs in a single batch, then deduplicate/sort and
         # truncate back to archive_size ONCE per generation. Previously this
         # looped per-output calling append + deduplicate (which sorts), so the
@@ -361,10 +443,17 @@ def sync_worker_meta(
     In the ``processes`` backend each worker holds its own copy of the arg
     provider (shipped once with the goal function), so the optimizer passes the
     small live-metadata dict each generation and the worker merges it here before
-    evaluating the goal function.
+    evaluating the goal function. That dict also carries ``_eval_base`` — the
+    authoritative global evaluation count — so the worker restarts its local
+    counter offset by it, keeping ``eval_count`` a true global running total (see
+    ``_ArgProvider``). Threads share the parent's provider and ship no base.
     """
-    if arg_provider is not None and meta:
-        arg_provider.meta.update(meta)
+    if arg_provider is None or not meta:
+        return
+    base = meta.pop("_eval_base", None)
+    arg_provider.meta.update(meta)
+    if base is not None:
+        arg_provider.reset_local(base)
 
 
 def check_stop_early(

--- a/src/optimizers/continuous/ga.py
+++ b/src/optimizers/continuous/ga.py
@@ -134,6 +134,7 @@ def run_ga(
         return OptimizerRun(
             population_solutions=new_population,
             population_values=new_population_fitness,
+            eval_count=arg_provider.eval_delta,
         )
 
     # Vectorize the genetic operators across the whole batch of offspring; only
@@ -161,7 +162,9 @@ def run_ga(
             new_population[row, :] = c2
             new_population_fitness[row] = f2
     return OptimizerRun(
-        population_solutions=new_population, population_values=new_population_fitness
+        population_solutions=new_population,
+        population_values=new_population_fitness,
+        eval_count=arg_provider.eval_delta,
     )
 
 

--- a/src/optimizers/continuous/pso.py
+++ b/src/optimizers/continuous/pso.py
@@ -83,7 +83,11 @@ def run_particles(
             s, v = apply_local_optimization(fcn, local_optim, children[k], variables)
             positions[k] = s
             values[k] = v
-        return OptimizerRun(population_values=values, population_solutions=positions)
+        return OptimizerRun(
+            population_values=values,
+            population_solutions=positions,
+            eval_count=arg_provider.eval_delta,
+        )
 
     # Native PSO path: global best is the archive's top entry (best-first).
     global_best_position = solution_archive[0, :]
@@ -136,7 +140,11 @@ def run_particles(
             swarm_best_val = new_vals[iter_best]
             swarm_best_pos = p_pos[iter_best, :].copy()
     # Return the positions and values
-    return OptimizerRun(population_values=p_best_val, population_solutions=p_best_pos)
+    return OptimizerRun(
+        population_values=p_best_val,
+        population_solutions=p_best_pos,
+        eval_count=arg_provider.eval_delta,
+    )
 
 
 class ParticleSwarmOptimizer(IOptimizer):

--- a/src/optimizers/core/base.py
+++ b/src/optimizers/core/base.py
@@ -110,6 +110,7 @@ class OptimizerRun:
     population_values: AF  # (N_generations x N_vars)
     population_solutions: AF  # (1 x N_vars)
     population_outputs: AF | None = None  # (N x n_outputs) tracked outputs, QD add-on
+    eval_count: int = 0  # objective evaluations this worker did this generation
 
 
 @dataclass

--- a/tests/test_runtime_args.py
+++ b/tests/test_runtime_args.py
@@ -1,6 +1,9 @@
+import copy
+
 import numpy as np
 import pytest
 
+from optimizers.continuous.base import _ArgProvider
 from optimizers.continuous.ga import (
     GeneticAlgorithmOptimizer,
     GeneticAlgorithmOptimizerConfig,
@@ -126,3 +129,99 @@ def test_metadata_injection_into_goal_and_constraints(tiny_ga_cfg):
 
     # After solve completes, optimizer should report finalize phase in its metadata
     assert getattr(opt, "_arg_provider").meta.get("phase") == "finalize"
+
+
+def test_arg_provider_eval_count_is_global_across_workers():
+    """The eval_count protocol yields a true global running total.
+
+    Simulates the parent/worker flow used under the ``processes`` backend, where
+    each worker holds an independent copy of the arg provider: the parent ships a
+    global base, each worker counts up from it, and the parent folds the
+    per-worker deltas back into the authoritative total.
+    """
+    ap = _ArgProvider()
+
+    # Parent initialization pass: 5 evaluations, counted globally from zero.
+    for _ in range(5):
+        ap.bump_eval()
+    assert ap.eval_count == 5
+    assert ap.current()["eval_count"] == 5
+    # initialize() folds the init pass into the global base.
+    ap.commit(ap.eval_delta)
+    assert ap.eval_count == 5
+    assert ap.eval_delta == 0
+
+    # --- Generation 0: two independent process-worker copies ---
+    base = ap.eval_count
+    w1, w2 = copy.deepcopy(ap), copy.deepcopy(ap)
+    w1.reset_local(base)
+    w2.reset_local(base)
+    for _ in range(3):
+        w1.bump_eval()
+    for _ in range(4):
+        w2.bump_eval()
+    # Each worker's goal fn sees a globally-offset count, not a from-zero tally.
+    assert w1.current()["eval_count"] == base + 3
+    assert w2.current()["eval_count"] == base + 4
+    # The parent folds both per-worker deltas into the authoritative total.
+    ap.commit(w1.eval_delta + w2.eval_delta)
+    assert ap.eval_count == 5 + 3 + 4  # 12
+
+    # --- Generation 1 ---
+    base = ap.eval_count
+    w3 = copy.deepcopy(ap)
+    w3.reset_local(base)
+    for _ in range(6):
+        w3.bump_eval()
+    assert w3.current()["eval_count"] == 12 + 6
+    ap.commit(w3.eval_delta)
+    assert ap.eval_count == 18  # exact global total, no double counting
+
+
+def test_eval_count_global_under_processes_backend(monkeypatch):
+    """End-to-end regression guard for issue #34's runtime ``eval_count``.
+
+    Under the multiprocess backend each worker holds its own copy of the arg
+    provider, so a naive counter tallies evaluations per-worker and the run-level
+    count never reflects the global total. After the fix the parent's
+    ``eval_count`` must grow across generations with every worker's evaluations
+    folded in.
+    """
+    # Fast-mode caps force the backend to threads; disable so processes is used.
+    monkeypatch.setenv("OPTIMIZERS_FAST", "")
+
+    num_generations = 4
+    population_size = 12
+    cfg = GeneticAlgorithmOptimizerConfig(
+        name="GA-GlobalEvalCount",
+        num_generations=num_generations,
+        population_size=population_size,
+        solution_archive_size=24,
+        n_jobs=2,
+        joblib_prefer="processes",
+        stop_after_iterations=999,  # never early-stop on no-improvement
+        target_score=-1.0,  # never early-stop on target (sum-of-squares >= 0)
+        local_grad_optim="none",
+    )
+
+    def obj(x: AF, args: dict) -> F:
+        x = np.asarray(x, dtype=float)
+        return float(np.sum(x**2))
+
+    variables = [
+        InputContinuousVariable("x0", -5.0, 5.0),
+        InputContinuousVariable("x1", -5.0, 5.0),
+    ]
+    opt = GeneticAlgorithmOptimizer(cfg, obj, variables)
+    # Guard: the process backend must actually be in effect for this to be a
+    # meaningful test (fast mode would otherwise silently downgrade to threads).
+    assert opt.config.joblib_prefer == "processes"
+
+    opt.solve()
+
+    total = opt._arg_provider.eval_count
+    assert isinstance(total, int)
+    # Each generation evaluates ~2*population candidates across all workers, on top
+    # of the initialization pass. A per-worker counter would have stagnated near
+    # the small init count; require at least one full population per generation.
+    assert total >= num_generations * population_size


### PR DESCRIPTION
The runtime `eval_count` metadata injected into goal functions (issue #34)
was counted per-worker under the `processes` backend: each worker holds an
independent copy of the arg provider, so its counter started from the value
shipped at pool creation and never reflected the run-wide total. Only the
threads/n_jobs=1 paths (where the provider is shared) gave a global count.

Make the parent the single source of truth for the cumulative count:

- `_ArgProvider` now splits counting into `eval_base` (evaluations completed
  before the current context) and `_local` (evaluations since the last reset).
  The value the goal function reads as `eval_count` is always
  `eval_base + _local`, i.e. a true global running total.
- The parent's initialization pass is folded into the base (`commit`) before
  the generation loop, so the first generation continues from it.
- Under `processes`, the parent ships the authoritative base each generation
  (`live_meta` -> `_eval_base`); each worker restarts its local counter from it
  (`reset_local`) and reports its per-generation delta on `OptimizerRun`; the
  parent sums the deltas back into the base (`_accumulate_eval_count`).
- Under `threads` the provider is shared, so its counter is already global —
  no base is shipped and no folding happens (which would double-count).

Applies uniformly to the GA/ACO/PSO continuous solvers. Adds a unit test of
the parent/worker counting protocol and an end-to-end regression test on the
processes backend (guarded so fast-mode can't silently downgrade it to
threads). Full suite: 116 passed.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_015ucFcswTycYBxBEBwHtWGQ