### PR TITLE
feat(gd): run gradient descent serially when nested in another optimizer

### DIFF
--- a/src/optimizers/continuous/gd.py
+++ b/src/optimizers/continuous/gd.py
@@ -114,6 +114,7 @@ class GradientDescentOptimizer(IOptimizer):
         fcn: GoalFcn,
         variables: InputVariables,
         args: InputArguments | None = None,
+        nested: bool = False,
     ):
         super().__init__(
             config,
@@ -124,6 +125,14 @@ class GradientDescentOptimizer(IOptimizer):
         self.config: GradientDescentOptimizerConfig = GradientDescentOptimizerConfig(
             **{**config.__dict__}
         )
+        # Gradient descent is a local-optimality search. When another optimization
+        # system drives it as an inner/nested solve (see MultiTypeOptimizer and
+        # GroupedVariableOptimizer), that outer system owns the parallelism — one
+        # GD per restart, per variable group, or per candidate. Parallelizing the
+        # discrete search inside each of those would spawn nested joblib pools and
+        # oversubscribe the CPU, so run GD serially in that case.
+        if nested:
+            self.config.n_jobs = 1
 
     def solve(self, preserve_percent: float = 0.0) -> OptimizerResult:
         """Solve the optimization problem using gradient descent.

--- a/src/optimizers/continuous/optimizer_strategy.py
+++ b/src/optimizers/continuous/optimizer_strategy.py
@@ -122,8 +122,10 @@ class MultiTypeOptimizer(IOptimizer):
                 converted_config, self.fcn, self.variables, self.args
             )
         elif selected_type == "gd":
+            # Nested local search: this strategy owns the higher-level search, so
+            # GD runs serially (see GradientDescentOptimizer's ``nested`` flag).
             optimizer = GradientDescentOptimizer(
-                converted_config, self.fcn, self.variables, self.args
+                converted_config, self.fcn, self.variables, self.args, nested=True
             )
         else:
             # Should be unreachable due to ensure_literal_choice
@@ -207,7 +209,12 @@ class GroupedVariableOptimizer(IOptimizer):
                 elif group.optimizer_type == "ga":
                     optim = GeneticAlgorithmOptimizer(config, new_fcn, group_vars)
                 elif group.optimizer_type == "gd":
-                    optim = GradientDescentOptimizer(config, new_fcn, group_vars)
+                    # Nested local search: the grouped optimizer owns the outer
+                    # loop over groups/rounds, so GD runs serially (see its
+                    # ``nested`` flag).
+                    optim = GradientDescentOptimizer(
+                        config, new_fcn, group_vars, nested=True
+                    )
                 else:
                     raise NotImplementedError("Optimizer not implemented")
                 result = optim.solve()

--- a/tests/test_optimizers.py
+++ b/tests/test_optimizers.py
@@ -194,6 +194,65 @@ def test_gd():
     assert soln is not None
 
 
+def test_gd_nested_flag_forces_serial():
+    # Gradient descent is a local search. Driven standalone it keeps its
+    # configured parallelism; driven as a nested/inner solve it must run serially
+    # so it does not oversubscribe the CPU on top of the outer system's parallelism.
+    variables = [
+        InputContinuousVariable("x", -5, 5),
+        InputContinuousVariable("y", -5, 5),
+    ]
+    cfg = GradientDescentOptimizerConfig(
+        name="gd-njobs",
+        n_jobs=4,
+        joblib_prefer="processes",
+        parallel_discrete_search=True,
+    )
+    standalone = GradientDescentOptimizer(cfg, optim_ackley, variables)
+    assert standalone.config.n_jobs == 4  # top-level GD keeps its parallelism
+    nested = GradientDescentOptimizer(cfg, optim_ackley, variables, nested=True)
+    assert nested.config.n_jobs == 1  # nested GD is forced serial
+
+
+def test_grouped_optimizer_runs_nested_gd_serially(monkeypatch):
+    # When a higher-level optimization system drives GD, it must construct it with
+    # nested=True (so the configured n_jobs is overridden to 1). Spy on the GD
+    # class the strategy module resolves and capture what it built.
+    from optimizers.continuous import optimizer_strategy as strat
+
+    captured: dict = {}
+    real_gd = strat.GradientDescentOptimizer
+
+    class SpyGD(real_gd):  # type: ignore[valid-type, misc]
+        def __init__(self, *args, **kwargs):
+            super().__init__(*args, **kwargs)
+            captured["nested"] = kwargs.get("nested", False)
+            captured["n_jobs"] = self.config.n_jobs
+
+    monkeypatch.setattr(strat, "GradientDescentOptimizer", SpyGD)
+
+    variables = [
+        InputContinuousVariable("x", -5, 5),
+        InputContinuousVariable("y", -5, 5),
+    ]
+    config = GroupedVariableOptimizerConfig(
+        name="grouped-gd",
+        num_rounds=1,
+        num_generations=2,
+        n_jobs=4,
+        joblib_prefer="processes",
+        groups=[
+            InputVariableGroup(name="g", variables=["x", "y"], optimizer_type="gd"),
+        ],
+    )
+    GroupedVariableOptimizer(
+        config=config, variables=variables, fcn=optim_ackley
+    ).solve()
+
+    assert captured.get("nested") is True
+    assert captured.get("n_jobs") == 1
+
+
 def test_pso():
     input_variables = [
         InputContinuousVariable("x", -15, 30),


### PR DESCRIPTION
## What

Gradient descent is a local-optimality search, so it's typically driven by a higher-level optimization system that already owns the parallelism — one GD per restart (`MultiTypeOptimizer`) or per variable group (`GroupedVariableOptimizer`). Letting GD's `parallel_discrete_search` spin up its own joblib pool inside each of those nests parallel pools and oversubscribes the CPU.

This adds a `nested` flag to `GradientDescentOptimizer` and sets it wherever a strategy optimizer drives GD as an inner solve.

## Changes

- **`continuous/gd.py`** — `GradientDescentOptimizer.__init__` gains `nested: bool = False`. When set, it forces `n_jobs = 1` so joblib runs inline with no worker spawn, turning off GD's internal parallelism while preserving the discrete-search behavior (just serial).
- **`continuous/optimizer_strategy.py`** — `MultiTypeOptimizer` and `GroupedVariableOptimizer` now construct GD with `nested=True`, since they own the higher-level search loop.

Standalone/top-level GD is unaffected and keeps its configured parallelism. The `apply_local_optimization` path (GD used as per-individual local search inside GA/ACO/PSO) already called the `solve_gd_*` scipy helpers directly and was never parallelized, so no change was needed there.

## Testing

- `test_gd_nested_flag_forces_serial` — nested GD forces `n_jobs=1`; standalone keeps its configured `n_jobs`.
- `test_grouped_optimizer_runs_nested_gd_serially` — spies on the strategy's GD construction to confirm `nested=True` and `n_jobs==1`.
- Existing `test_gd` (parallel top-level GD) unchanged and still passes.
- Full suite: **118 passed**; `black --check` clean; flake8 clean on changed files at the 120-char config; mypy error count unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_015ucFcswTycYBxBEBwHtWGQ)_