### PR TITLE
Ratchet up flake8 and mypy strictness

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,7 +57,7 @@ extend-ignore = ["E203"]
 # Complexity ceiling set at the current worst (_three_opt_kernel's 8-way
 # reconnection switch = 24). It only guards against regressions; ratchet it
 # down over time as complex functions are simplified.
-max-complexity = 24
+max-complexity = 18
 
 [tool.mypy]
 python_version = "3.10"
@@ -78,6 +78,11 @@ disallow_untyped_calls = true
 disallow_any_generics = true
 strict_equality = true
 warn_return_any = true
+# Ratchet 3: additional strictness
+warn_unused_variables = true
+warn_unreachable = true
+no_implicit_reexport = true
+strict_optional = true
 
 # --- Ratchet baseline -------------------------------------------------------
 # The modules below still carry numpy dtype-union errors: the AF/AI aliases are


### PR DESCRIPTION
- Lower flake8 max-complexity from 24 to 18
- Add mypy settings: warn_unused_variables, warn_unreachable, no_implicit_reexport, strict_optional