### PR TITLE
Give each parallel task its own random stream so seeded runs reproduce

### DIFF
--- a/src/optimizers/core/parallel.py
+++ b/src/optimizers/core/parallel.py
@@ -27,6 +27,7 @@ from joblib import cpu_count
 from joblib.externals.loky import ProcessPoolExecutor
 
 from .base import JoblibPrefer
+from .random import spawn_streams, use_stream
 
 # Per-worker cache of run-constant payloads, keyed by an opaque token. Populated
 # once per worker process by the pool initializer. This lives at module scope on
@@ -48,10 +49,20 @@ def _init_worker(token: str, payload: Any) -> None:
 
 
 def _call_with_fixed(
-    worker_fn: Callable[..., Any], token: str, args: Sequence[Any]
+    worker_fn: Callable[..., Any], token: str, args: Sequence[Any], stream: Any
 ) -> Any:
-    # Runs in the worker: resolve the once-shipped fixed payload and call through.
-    return worker_fn(_FIXED[token], *args)
+    # Runs in the worker: resolve the once-shipped fixed payload and call through,
+    # standing in this task's own random stream (see `_call_with_stream`).
+    with use_stream(stream):
+        return worker_fn(_FIXED[token], *args)
+
+
+def _call_with_stream(
+    worker_fn: Callable[..., Any], fixed: Any, args: Sequence[Any], stream: Any
+) -> Any:
+    # Threads backend: same, but `fixed` is shared memory rather than shipped.
+    with use_stream(stream):
+        return worker_fn(fixed, *args)
 
 
 class GenerationRunner:
@@ -114,20 +125,38 @@ class GenerationRunner:
         """Call ``worker_fn(fixed, *varying_args)`` ``count`` times in parallel.
 
         ``count`` defaults to ``n_jobs`` (one task per worker per generation).
+
+        Each call gets its own random stream, spawned here in the parent. Without
+        that the tasks all draw from one shared ``numpy.random.Generator``, which
+        is not thread-safe and hands out numbers in scheduler order -- so a run
+        with a fixed seed produced a different answer every time at ``n_jobs > 1``.
+        Streams are keyed by task index, and results are collected in submission
+        order, so which numbers a task sees no longer depends on when it happened
+        to run.
+
+        The guarantee is reproducibility *at a given* ``n_jobs``, not across
+        values of it: the population is split ``population_size // n_jobs`` ways,
+        so changing the worker count changes how the search is partitioned and
+        therefore where it goes. That was true before this change too, and is a
+        property of data-parallel population search rather than of the seeding.
         """
         n = self.n_jobs if count is None else count
+        streams = spawn_streams(n)
         if self.prefer == "processes":
             assert self._executor is not None
             futures = [
                 self._executor.submit(
-                    _call_with_fixed, worker_fn, self._token, varying_args
+                    _call_with_fixed, worker_fn, self._token, varying_args, streams[i]
                 )
-                for _ in range(n)
+                for i in range(n)
             ]
             return [f.result() for f in futures]
         assert self._parallel is not None
         return self._parallel(
-            joblib.delayed(worker_fn)(self._fixed, *varying_args) for _ in range(n)
+            joblib.delayed(_call_with_stream)(
+                worker_fn, self._fixed, varying_args, streams[i]
+            )
+            for i in range(n)
         )
 
     def close(self) -> None:

--- a/src/optimizers/core/random.py
+++ b/src/optimizers/core/random.py
@@ -1,11 +1,30 @@
 import os
 import random as pyrandom
+import threading
+from contextlib import contextmanager
+from typing import Iterator
 
 import numpy as np
 
 # Global state for deterministic randomness across the project
 _current_seed: int | None = None
 _global_rng: np.random.Generator | None = None
+
+# Root of the per-worker stream family. Kept separate from `_global_rng` so the
+# main thread's number stream is byte-for-byte what it was before worker streams
+# existed, and so the workers' streams are provably independent of it rather
+# than children of the very sequence the main thread is drawing from.
+_worker_sequence: np.random.SeedSequence | None = None
+
+# Domain separator mixed into the worker root. Any fixed constant works; it only
+# has to differ from the main stream's seeding so the two families cannot
+# accidentally coincide.
+_WORKER_DOMAIN = 0x5715_1CE5
+
+# A parallel worker's own generator, set for the duration of one task. Thread
+# state rather than global state because that is exactly the scope: concurrent
+# tasks must not see each other's stream, and the main thread must keep its own.
+_thread_local = threading.local()
 
 
 def _new_entropy_seed() -> int:
@@ -20,7 +39,7 @@ def set_seed(seed: int | None) -> int:
     If seed is None, a fresh seed is generated from OS entropy.
     Returns the seed actually used.
     """
-    global _current_seed, _global_rng
+    global _current_seed, _global_rng, _worker_sequence
     if seed is None:
         seed = _new_entropy_seed()
     _current_seed = int(seed)
@@ -30,6 +49,10 @@ def set_seed(seed: int | None) -> int:
     np.random.seed(_current_seed)
     # Create our shared Generator
     _global_rng = np.random.default_rng(_current_seed)
+    # And the root the per-worker streams are spawned from.
+    _worker_sequence = np.random.SeedSequence([_current_seed, _WORKER_DOMAIN])
+    # A seed change invalidates any stream this thread was standing in.
+    _thread_local.rng = None
     return _current_seed
 
 
@@ -40,11 +63,53 @@ def get_seed() -> int | None:
 
 def rng() -> np.random.Generator:
     """
-    Return the shared NumPy Generator. If no seed was set yet, create one using
-    fresh entropy so default behavior remains non-deterministic unless the
-    caller opted in via set_seed(...).
+    Return the Generator the calling code should draw from.
+
+    Inside a parallel worker task (see :func:`use_stream`) that is the task's own
+    stream; everywhere else it is the shared global Generator. If no seed was set
+    yet, create one using fresh entropy so default behavior remains
+    non-deterministic unless the caller opted in via set_seed(...).
     """
+    local: np.random.Generator | None = getattr(_thread_local, "rng", None)
+    if local is not None:
+        return local
     if _global_rng is None:
         set_seed(None)
     assert _global_rng is not None
     return _global_rng
+
+
+def spawn_streams(n: int) -> list[np.random.Generator]:
+    """``n`` independent Generators, derived deterministically from the seed.
+
+    ``numpy.random.Generator`` is **not thread-safe**, so parallel workers sharing
+    one Generator both race on its internal state and consume draws in whatever
+    order the scheduler happens to pick -- which makes a seeded run irreproducible.
+    Giving each task its own spawned stream fixes both: the streams are
+    independent by construction (``SeedSequence.spawn``), and which numbers a task
+    sees depends on its index, not on when it happens to run.
+
+    Successive calls return successive families, so a per-generation call gives
+    every generation fresh numbers while remaining a pure function of the seed and
+    the call order. Call it from one thread -- the counter it advances is not
+    itself synchronized.
+    """
+    if _worker_sequence is None:
+        set_seed(None)
+    assert _worker_sequence is not None
+    return [np.random.default_rng(child) for child in _worker_sequence.spawn(n)]
+
+
+@contextmanager
+def use_stream(generator: np.random.Generator) -> Iterator[None]:
+    """Make ``generator`` the result of :func:`rng` on this thread, for a task.
+
+    Restores whatever was in place on exit, so nesting is safe and a worker
+    thread reused by a later task never inherits the previous task's stream.
+    """
+    previous: np.random.Generator | None = getattr(_thread_local, "rng", None)
+    _thread_local.rng = generator
+    try:
+        yield
+    finally:
+        _thread_local.rng = previous

--- a/tests/test_determinism.py
+++ b/tests/test_determinism.py
@@ -1,0 +1,172 @@
+"""A seeded run must be reproducible, including in parallel.
+
+``set_seed(s)`` is the promise that a run is a pure function of ``s``. It was not
+kept at ``n_jobs > 1``: every parallel task drew from the one shared
+``numpy.random.Generator`` returned by ``core.random.rng()``, which is not
+thread-safe, so the numbers a task received depended on when the scheduler got
+round to it. With a *pure deterministic* goal function and the same seed, five
+identical GA runs made 1294, 1272, 1293, 1273 and 1260 evaluations and reached
+five different optima.
+
+Each parallel task now gets its own stream, spawned in the parent from the seed
+and keyed by task index (``core.random.spawn_streams`` /
+``core.parallel.GenerationRunner.run``).
+
+The guarantee these tests pin is reproducibility *at a given* ``n_jobs``, not
+across values of it. The population is split ``population_size // n_jobs`` ways,
+so the worker count changes how the search is partitioned and therefore where it
+goes -- a property of data-parallel population search, not of the seeding.
+"""
+
+import io
+import contextlib
+
+import numpy as np
+import pytest
+
+from optimizers.continuous.aco import AntColonyOptimizer, AntColonyOptimizerConfig
+from optimizers.continuous.ga import (
+    GeneticAlgorithmOptimizer,
+    GeneticAlgorithmOptimizerConfig,
+)
+from optimizers.continuous.pso import (
+    ParticleSwarmOptimizer,
+    ParticleSwarmOptimizerConfig,
+)
+from optimizers.continuous.variables import InputContinuousVariable
+from optimizers.core.random import rng, set_seed, spawn_streams, use_stream
+
+OPTIMIZERS = {
+    "ga": (GeneticAlgorithmOptimizer, GeneticAlgorithmOptimizerConfig),
+    "pso": (ParticleSwarmOptimizer, ParticleSwarmOptimizerConfig),
+    "aco": (AntColonyOptimizer, AntColonyOptimizerConfig),
+}
+
+
+def sphere(x):
+    """A pure function of x. Any variation in the result is the optimizer's."""
+    return float(np.sum((np.asarray(x, dtype=float) - 0.3) ** 2))
+
+
+def solve_once(kind, *, seed=0, n_jobs=1, prefer="threads", local_grad_optim="none"):
+    """One seeded run. Returns ``(best score, evaluation count)``."""
+    optimizer_cls, config_cls = OPTIMIZERS[kind]
+    set_seed(seed)
+
+    evaluations = []
+
+    def goal(x):
+        evaluations.append(1)
+        return sphere(x)
+
+    variables = [InputContinuousVariable(f"p{i}", -1.0, 1.0) for i in range(4)]
+    config = config_cls(
+        name=f"determinism-{kind}",
+        num_generations=4,
+        population_size=16,
+        solution_archive_size=32,
+        stop_after_iterations=8,
+        n_jobs=n_jobs,
+        joblib_prefer=prefer,
+        local_grad_optim=local_grad_optim,
+    )
+    with (
+        contextlib.redirect_stdout(io.StringIO()),
+        contextlib.redirect_stderr(io.StringIO()),
+    ):
+        result = optimizer_cls(config, goal, variables).solve()
+    return round(float(result.solution_score), 12), len(evaluations)
+
+
+@pytest.mark.parametrize("kind", list(OPTIMIZERS))
+@pytest.mark.parametrize("n_jobs", [1, 3])
+def test_same_seed_same_result(kind, n_jobs):
+    """The headline promise, at one and at several workers."""
+    runs = [solve_once(kind, n_jobs=n_jobs) for _ in range(3)]
+    assert len(set(runs)) == 1, f"{kind} at n_jobs={n_jobs} varied across runs: {runs}"
+
+
+@pytest.mark.parametrize("local_grad_optim", ["none", "perturb", "single-var-grad"])
+def test_local_search_is_also_reproducible(local_grad_optim):
+    """The local polish runs inside the worker tasks, so it draws from the
+    task's stream too."""
+    runs = [
+        solve_once("ga", n_jobs=3, local_grad_optim=local_grad_optim) for _ in range(3)
+    ]
+    assert len(set(runs)) == 1, f"{local_grad_optim} varied: {runs}"
+
+
+def test_processes_backend_is_reproducible():
+    runs = [solve_once("ga", n_jobs=2, prefer="processes") for _ in range(3)]
+    assert len(set(runs)) == 1, f"processes backend varied: {runs}"
+
+
+def test_different_seeds_still_differ():
+    """Reproducibility must not have been bought by making the seed inert."""
+    assert solve_once("ga", seed=0, n_jobs=3) != solve_once("ga", seed=1, n_jobs=3)
+
+
+# ---------------------------------------------------------------------------
+# The stream machinery itself
+# ---------------------------------------------------------------------------
+
+
+def test_spawned_streams_are_deterministic_and_distinct():
+    set_seed(7)
+    first = [g.random(4).tolist() for g in spawn_streams(3)]
+    set_seed(7)
+    second = [g.random(4).tolist() for g in spawn_streams(3)]
+
+    assert first == second, "the same seed must produce the same stream family"
+    assert first[0] != first[1] != first[2], "workers must not share a stream"
+
+
+def test_successive_spawns_give_fresh_numbers():
+    """One family per generation: reproducible, but not the same numbers every
+    generation."""
+    set_seed(7)
+    generation_one = [g.random(4).tolist() for g in spawn_streams(2)]
+    generation_two = [g.random(4).tolist() for g in spawn_streams(2)]
+    assert generation_one != generation_two
+
+
+def test_use_stream_scopes_to_the_calling_thread_and_restores():
+    set_seed(7)
+    outer = rng()
+    (stream,) = spawn_streams(1)
+
+    with use_stream(stream):
+        assert rng() is stream
+    assert rng() is outer, "the task's stream must not leak past the task"
+
+
+def test_use_stream_nests():
+    set_seed(7)
+    first, second = spawn_streams(2)
+    with use_stream(first):
+        with use_stream(second):
+            assert rng() is second
+        assert rng() is first
+
+
+def test_set_seed_clears_a_stale_stream():
+    """Re-seeding mid-flight must not leave the thread standing in a stream
+    derived from the previous seed."""
+    set_seed(7)
+    (stream,) = spawn_streams(1)
+    with use_stream(stream):
+        set_seed(8)
+        assert rng() is not stream
+
+
+def test_worker_streams_do_not_disturb_the_main_stream():
+    """The main thread's numbers are the same whether or not workers ran, so
+    adding the worker family did not shift existing seeded behaviour."""
+    set_seed(11)
+    expected = rng().random(5).tolist()
+
+    set_seed(11)
+    spawn_streams(4)
+    for generator in spawn_streams(4):
+        generator.random(10)
+    assert rng().random(5).tolist() == expected


### PR DESCRIPTION
## The bug

`set_seed(s)` promises that a run is a pure function of `s`. At `n_jobs > 1` it is not.

Every parallel task calls `core.random.rng()`, which returns one process-wide `numpy.random.Generator`. That object is **not thread-safe**: concurrent tasks race on its internal state and each receives whatever numbers it happens to reach first, so the search follows a different path on every run.

It is not subtle once measured. A GA with a **pure deterministic** goal function (`sum((x - 0.3)**2)`), `set_seed(0)` before each run, `n_jobs=4`:

```
evaluations: 1294, 1272, 1293, 1273, 1260   →  five different optima
```

Same seed, same config, same process. Reproducible only by accident at `n_jobs=1`.

Found downstream: `tribble-fis` pins this package for antecedent refinement and had a test failing ~1 run in 6 because of it.

## The fix

Spawn a stream per task.

- **`core/random.py`** — `spawn_streams(n)` derives `n` independent generators from the seed via `SeedSequence.spawn`. `use_stream(gen)` installs one as thread state for the duration of a task, and `rng()` returns it when set. No call site had to learn about streams: every existing `global_rng()` caller keeps working and now transparently draws from the right stream.
- **`core/parallel.py`** — `GenerationRunner.run` spawns `n` streams and hands task `i` the `i`-th one. That is the single chokepoint all three continuous optimizers (GA, PSO, ACO) dispatch through, and results are already collected in submission order, so **which numbers a task sees depends on its index, not on when the scheduler got to it.**

Two details worth calling out:

**The worker family is rooted at `SeedSequence([seed, _WORKER_DOMAIN])`, not at the seed itself.** This keeps the main thread's stream byte-for-byte what it was — existing seeded behaviour outside the workers does not move — and it makes the worker streams provably independent of the stream the parent is drawing from, rather than children of a sequence that is also being consumed directly.

**The guarantee is reproducibility *at a given* `n_jobs`, not across values of it.** The population is split `population_size // n_jobs` ways, so the worker count changes how the search is partitioned and therefore where it goes. That was already true and is a property of data-parallel population search, not of the seeding — `test_same_seed_same_result` is parameterised over `n_jobs` rather than comparing across it, and the docstrings say so rather than implying a stronger promise.

## Verification

Deterministic over 3 repeats for every combination measured:

| | n_jobs=1 | n_jobs=3 |
|---|---|---|
| GA / PSO / ACO × `local_grad_optim` ∈ {none, perturb, single-var-grad} | ✅ | ✅ |
| processes backend | ✅ | ✅ |

**The tests catch the bug, not just the fixture.** Reverting only the `parallel.py` change (keeping the new `random.py` API so the file still imports) fails 7 of the 17 new tests — every parallel one — and passes the 10 that don't exercise parallelism:

```
FAILED tests/test_determinism.py::test_same_seed_same_result[3-ga]
FAILED tests/test_determinism.py::test_same_seed_same_result[3-pso]
FAILED tests/test_determinism.py::test_same_seed_same_result[3-aco]
FAILED tests/test_determinism.py::test_local_search_is_also_reproducible[none]
FAILED tests/test_determinism.py::test_local_search_is_also_reproducible[perturb]
FAILED tests/test_determinism.py::test_local_search_is_also_reproducible[single-var-grad]
FAILED tests/test_determinism.py::test_processes_backend_is_reproducible
7 failed, 10 passed
```

`test_determinism.py` also pins the things that would make the fix hollow: different seeds must still differ (reproducibility not bought by making the seed inert), `use_stream` must scope to one thread and restore on exit (no leaking into a reused worker thread), successive spawns must give fresh numbers (not the same draws every generation), `set_seed` must clear a stale stream, and the main stream must be unchanged by worker activity.

## Checks

- `pytest tests/ --fast` — **139 passed** (122 before, 17 new). Full-fidelity run also green.
- `black --check` clean, `flake8 ./src ./tests` clean.
- `mypy -p optimizers` — 13 errors, byte-identical to `main`; none in the changed files.

## Not addressed here

Two legacy-global RNG uses remain outside the parallel path — `solution_deck.lloyds_algorithm_points` (`np.random.random`) and `gd.py`'s discrete-variable pick (`np.random.randint`). Both are reached by `set_seed`'s `np.random.seed(...)` so they are seeded, but they draw from the legacy global rather than the shared generator and would need the same treatment if they were ever called from workers. Left alone to keep this diff to the actual defect — happy to fold them in if you'd prefer.

---
_Generated by [Claude Code](https://claude.ai/code/session_01HDQxwmw2NorWmWnEwRm31G)_