### PR TITLE
Route every draw through the seeded generator

### DIFF
--- a/src/optimizers/combinatorial/aco.py
+++ b/src/optimizers/combinatorial/aco.py
@@ -4,6 +4,8 @@ from typing import Optional
 import numpy as np
 from joblib import delayed
 
+from ..core.random import rng, run_in_stream, spawn_streams
+
 from .base import CombinatoricsResult, TSPBase, _check_stop_early
 from .strategy import TwoOptTSPConfig, TwoOptTSP
 from ..core.base import IOptimizerConfig, setup_for_generations
@@ -87,8 +89,13 @@ class AntColonyTSP(TSPBase):
                         )
                     return results
 
+                # One stream per task, so the draws inside the workers are a
+                # function of the seed and the task index rather than of the
+                # order the scheduler ran them in.
+                streams = spawn_streams(n_jobs)
                 all_results = parallel(
-                    delayed(parallel_ant)(i_ant) for i_ant in range(n_jobs)
+                    delayed(run_in_stream)(streams[i_ant], parallel_ant, i_ant)
+                    for i_ant in range(n_jobs)
                 )
 
                 for ant, result_gen in enumerate(all_results):
@@ -205,7 +212,7 @@ def run_ant(
         # Choose the next city via inverse-CDF sampling (report item #10):
         # cheaper than np.random.choice(..., p=p), which re-validates and
         # re-cumsums p on every call and takes a global lock.
-        cur_city = int(np.searchsorted(np.cumsum(p), np.random.random()))
+        cur_city = int(np.searchsorted(np.cumsum(p), rng().random()))
         if cur_city >= eta_shape_:
             cur_city = eta_shape_ - 1
         total_length += network_routes[city_order[idx], cur_city]

--- a/src/optimizers/combinatorial/aco_mst.py
+++ b/src/optimizers/combinatorial/aco_mst.py
@@ -6,6 +6,7 @@ from joblib import delayed
 from .base import CombinatoricsResult, TSPBase, _check_stop_early
 from ..core.base import setup_for_generations
 from ..core.types import AI, AF, F, ab8, i32, i16
+from ..core.random import rng, run_in_stream, spawn_streams
 from .aco import AntColonyTSPConfig
 
 # NOTE - MST is the same as TSP parameters, except the "back to start" is ignored.
@@ -67,8 +68,13 @@ class AntColonyMST(TSPBase):
                         )
                     return results
 
+                # One stream per task, so the draws inside the workers are a
+                # function of the seed and the task index rather than of the
+                # order the scheduler ran them in.
+                streams = spawn_streams(n_jobs)
                 all_results = parallel(
-                    delayed(parallel_ant)(i_ant) for i_ant in range(n_jobs)
+                    delayed(run_in_stream)(streams[i_ant], parallel_ant, i_ant)
+                    for i_ant in range(n_jobs)
                 )
 
                 for ant, result_gen in enumerate(all_results):
@@ -162,7 +168,7 @@ def run_ant_mst(
             break
         # Choose the next city-pair, must flatten probability matrix first
         cum_p = np.cumsum(p.flatten())
-        new_p = np.random.random()
+        new_p = rng().random()
         choice_idx = np.argmin(new_p > cum_p)
         from_row = choice_idx // order_len
         from_col = choice_idx % order_len

--- a/src/optimizers/combinatorial/ga.py
+++ b/src/optimizers/combinatorial/ga.py
@@ -4,6 +4,8 @@ from typing import Optional
 import numpy as np
 from joblib import delayed
 
+from ..core.random import rng, run_in_stream, spawn_streams
+
 from .base import TSPBase, CombinatoricsResult, _check_stop_early, check_path_distance
 from .strategy import TwoOptTSPConfig, TwoOptTSP
 from ..core import IOptimizerConfig
@@ -48,7 +50,7 @@ class GeneticAlgorithmTSP(TSPBase):
         # Create a bunch of random entries in the genome, each row is a permutation of [0, N), but 0 is always first
         permute_city = np.r_[1 : self.network_routes.shape[1]]
         for i in range(self.config.solution_archive_size):
-            genome[i, 1:] = np.random.permutation(permute_city)
+            genome[i, 1:] = rng().permutation(permute_city)
             genome_value[i] = check_path_distance(
                 self.network_routes, genome[i], self.config.back_to_start
             )
@@ -83,8 +85,13 @@ class GeneticAlgorithmTSP(TSPBase):
                         )
                     return results
 
+                # One stream per task, so the draws inside the workers are a
+                # function of the seed and the task index rather than of the
+                # order the scheduler ran them in.
+                streams = spawn_streams(n_jobs)
                 all_results = parallel(
-                    delayed(parallel_ga)(i_ant) for i_ant in range(n_jobs)
+                    delayed(run_in_stream)(streams[i_ant], parallel_ga, i_ant)
+                    for i_ant in range(n_jobs)
                 )
 
                 # Collect this generation's offspring, then grow the genome with a
@@ -172,7 +179,7 @@ def run_ga(
 
 def _2opt_refine(new_route: AI, network_routes: AF, nearest_neighbors: int = 10) -> AI:
     N = len(new_route)
-    ij = np.random.randint(low=1, high=max(1, N - nearest_neighbors))
+    ij = int(rng().integers(low=1, high=max(1, N - nearest_neighbors)))
     k_nn = N
     if nearest_neighbors > 0:
         k_nn = min(k_nn, ij + nearest_neighbors)
@@ -194,14 +201,14 @@ def _2opt_refine(new_route: AI, network_routes: AF, nearest_neighbors: int = 10)
 
 
 def _mutate(child: AI, mutation_rate: F, network_routes: AF) -> AI:
-    if np.random.rand() < mutation_rate:
+    if rng().random() < mutation_rate:
         # Swap a percentage of the variables
         n_swaps = max(1, int(np.round(mutation_rate * len(child) / 2.0)))
         candidate_swaps = np.r_[1 : len(child) - 1]
         for _ in range(n_swaps):
-            ij, jk = np.random.choice(candidate_swaps, 2, replace=False)
+            ij, jk = rng().choice(candidate_swaps, 2, replace=False)
             # Support a handful of specific operations (as per Anoop): swap, slide, and flip
-            action_choice = np.random.randint(3)
+            action_choice = int(rng().integers(3))
             if action_choice == 0:
                 # Swap
                 child[ij], child[jk] = child[jk], child[ij]
@@ -223,7 +230,7 @@ def _tournament_selection(
     tournament_size: int = 3,
 ) -> AF | AI:
     # Randomly sample row
-    row_idxs = np.random.choice(
+    row_idxs = rng().choice(
         population_deck.shape[0], size=tournament_size, replace=False
     )
     # Take the optimal row from the option
@@ -235,10 +242,10 @@ def _crossover(
     parent1: AF | AI, parent2: AF | AI, crossover_rate: float
 ) -> tuple[AF | AI, AF | AI]:
     # Randomly pick a point in the array that the swap starts
-    if np.random.rand() < crossover_rate:
-        crossover_idx = np.random.choice(len(parent1))
+    if rng().random() < crossover_rate:
+        crossover_idx = int(rng().choice(len(parent1)))
         # Preallocate a full length sequence to ensure each child has ALL entries
-        all_entries = np.random.permutation(parent1.shape[0])
+        all_entries = rng().permutation(parent1.shape[0])
         child1 = np.concatenate(
             [parent1[:crossover_idx], parent2[crossover_idx:], all_entries], axis=0
         )

--- a/src/optimizers/continuous/gd.py
+++ b/src/optimizers/continuous/gd.py
@@ -12,6 +12,7 @@ from ..core.base import (
     InputArguments,
 )
 from ..core.types import AF
+from ..core.random import rng, run_in_stream, spawn_streams
 from ..solution_deck import (
     WrappedGoalFcn,
     InputVariables,
@@ -150,7 +151,7 @@ class GradientDescentOptimizer(IOptimizer):
             if self.config.discrete_search_size < 1:
                 self.config.discrete_search_size = n_disc_vars
             # Randomly pick the which discrete variable to tweak on each run
-            rand_vars = np.random.randint(
+            rand_vars = rng().integers(
                 low=0, high=n_disc_vars, size=self.config.discrete_search_size
             )
             with tqdm_joblib(
@@ -160,11 +161,18 @@ class GradientDescentOptimizer(IOptimizer):
                     n_jobs=self.config.n_jobs,
                     prefer=self.config.joblib_prefer,
                 )
+                # One stream per restart, so each restart's draws are a function
+                # of the seed and its index rather than of scheduling order.
+                streams = spawn_streams(len(rand_vars))
                 job_output: list[OptimizerResult] = parallel(
-                    joblib.delayed(solve_gd_with_mutate)(
-                        self.variables, disc_var_idxs[r_v], self.wrapped_fcn
+                    joblib.delayed(run_in_stream)(
+                        streams[i],
+                        solve_gd_with_mutate,
+                        self.variables,
+                        disc_var_idxs[r_v],
+                        self.wrapped_fcn,
                     )
-                    for r_v in rand_vars
+                    for i, r_v in enumerate(rand_vars)
                 )
                 # Pick the best solution of the output options
                 job_output = sorted(job_output, key=lambda x: x.solution_score)

--- a/src/optimizers/core/random.py
+++ b/src/optimizers/core/random.py
@@ -2,7 +2,7 @@ import os
 import random as pyrandom
 import threading
 from contextlib import contextmanager
-from typing import Iterator
+from typing import Any, Callable, Iterator
 
 import numpy as np
 
@@ -98,6 +98,23 @@ def spawn_streams(n: int) -> list[np.random.Generator]:
         set_seed(None)
     assert _worker_sequence is not None
     return [np.random.default_rng(child) for child in _worker_sequence.spawn(n)]
+
+
+def run_in_stream(
+    generator: np.random.Generator,
+    fn: Callable[..., Any],
+    *args: Any,
+    **kwargs: Any,
+) -> Any:
+    """Call ``fn(*args, **kwargs)`` with ``generator`` as this thread's :func:`rng`.
+
+    The dispatch-site form of :func:`use_stream`, for the optimizers that build
+    their own ``joblib.Parallel`` rather than going through
+    :class:`~optimizers.core.parallel.GenerationRunner`. Defined at module scope
+    so it pickles for the processes backend.
+    """
+    with use_stream(generator):
+        return fn(*args, **kwargs)
 
 
 @contextmanager

--- a/src/optimizers/solution_deck.py
+++ b/src/optimizers/solution_deck.py
@@ -7,7 +7,7 @@ from kmodes.kmodes import KModes
 
 from .core.base import ensure_literal_choice
 from .core.base import WrappedGoalFcn as WrappedGoalFcn  # re-exported
-from .core.random import get_seed
+from .core.random import get_seed, rng
 from .core.types import f64, af64, ab8, b8
 from .core.variables import InputVariables as InputVariables  # re-exported
 
@@ -297,7 +297,6 @@ class SolutionDeck:
         return deck
 
 
-@lru_cache(maxsize=16)
 def lloyds_algorithm_points(n: int, k: int, n_steps: int = 10) -> af64:
     """
     Generate N points uniformly distributed on the unit hyper-cube [0,1]^k using Lloyd's algorithm.
@@ -307,11 +306,19 @@ def lloyds_algorithm_points(n: int, k: int, n_steps: int = 10) -> af64:
         k (int): Dimension of the hyper-cube.
         n_steps (int): Number of iterations for Lloyd's algorithm.
     """
-    from sklearn.cluster import KMeans
-    from optimizers.core.random import get_seed
+    # Cached on the seed as well as the shape. The result is a function of both,
+    # so keying on the shape alone let the cache hand back points generated under
+    # whichever seed happened to call first -- a later `set_seed` was simply
+    # ignored for any (n, k, n_steps) already seen.
+    return _lloyds_algorithm_points(n, k, n_steps, get_seed())
 
-    kmeans = KMeans(n_clusters=n, random_state=get_seed())
-    points = np.sort(np.random.random(size=(n, k)), axis=0)
+
+@lru_cache(maxsize=16)
+def _lloyds_algorithm_points(n: int, k: int, n_steps: int, seed: int | None) -> af64:
+    from sklearn.cluster import KMeans
+
+    kmeans = KMeans(n_clusters=n, random_state=seed)
+    points = np.sort(rng().random(size=(n, k)), axis=0)
 
     for step in range(n_steps):
         kmeans.fit_predict(points)

--- a/tests/test_determinism.py
+++ b/tests/test_determinism.py
@@ -107,6 +107,118 @@ def test_different_seeds_still_differ():
 
 
 # ---------------------------------------------------------------------------
+# The combinatorial solvers, which build their own `joblib.Parallel` rather than
+# going through `GenerationRunner` and so need the streams wired in separately.
+# ---------------------------------------------------------------------------
+
+
+def city_distances(n=12):
+    from sklearn.metrics import pairwise_distances
+
+    return pairwise_distances(np.random.RandomState(3).uniform(0, 10, size=(n, 2)))
+
+
+def solve_tsp_once(kind, *, seed=0, n_jobs=1):
+    from optimizers.combinatorial.aco import AntColonyTSP, AntColonyTSPConfig
+    from optimizers.combinatorial.ga import (
+        GeneticAlgorithmTSP,
+        GeneticAlgorithmTSPConfig,
+    )
+
+    optimizer_cls, config_cls = {
+        "ga": (GeneticAlgorithmTSP, GeneticAlgorithmTSPConfig),
+        "aco": (AntColonyTSP, AntColonyTSPConfig),
+    }[kind]
+    set_seed(seed)
+    config = config_cls(
+        name=f"determinism-tsp-{kind}",
+        num_generations=4,
+        population_size=8,
+        solution_archive_size=16,
+        stop_after_iterations=8,
+        n_jobs=n_jobs,
+        joblib_prefer="threads",
+    )
+    with (
+        contextlib.redirect_stdout(io.StringIO()),
+        contextlib.redirect_stderr(io.StringIO()),
+    ):
+        result = optimizer_cls(config, city_distances()).solve()
+    return round(float(result.optimal_value), 10)
+
+
+@pytest.mark.parametrize("kind", ["ga", "aco"])
+@pytest.mark.parametrize("n_jobs", [1, 3])
+def test_tsp_same_seed_same_result(kind, n_jobs):
+    runs = [solve_tsp_once(kind, n_jobs=n_jobs) for _ in range(3)]
+    assert len(set(runs)) == 1, f"TSP {kind} at n_jobs={n_jobs} varied: {runs}"
+
+
+@pytest.mark.parametrize("kind", ["ga", "aco"])
+def test_tsp_different_seeds_still_differ(kind):
+    a = [solve_tsp_once(kind, seed=s, n_jobs=3) for s in range(6)]
+    assert len(set(a)) > 1, f"TSP {kind} ignored its seed: {a}"
+
+
+# ---------------------------------------------------------------------------
+# Every draw goes through the seeded generator
+# ---------------------------------------------------------------------------
+
+
+def test_no_legacy_global_random_calls_remain():
+    """`set_seed` can only govern draws that go through `rng()`.
+
+    The legacy `np.random.*` functions are a *separate* generator with separate
+    state. `set_seed` does seed them, so they were reproducible in a single
+    thread -- but they cannot participate in the per-task streams, so any of them
+    reached from a worker is unseedable in parallel however the dispatch is
+    wired. Grepping is crude, but it is the only check that stays true for code
+    nobody has written yet.
+    """
+    import pathlib
+    import re
+
+    source_root = pathlib.Path(__file__).resolve().parents[1] / "src" / "optimizers"
+    # `np.random.seed` and the Generator constructors are the seeding machinery
+    # itself, not draws from the legacy global.
+    allowed = re.compile(
+        r"np\.random\.(seed|default_rng|Generator|SeedSequence|RandomState)\b"
+    )
+    offender = re.compile(r"np\.random\.[A-Za-z_]+\s*\(")
+
+    found = []
+    for path in sorted(source_root.rglob("*.py")):
+        for number, line in enumerate(path.read_text().splitlines(), start=1):
+            code = line.split("#", 1)[0]
+            for match in offender.finditer(code):
+                if not allowed.match(match.group(0).rstrip("(").strip()):
+                    found.append(
+                        f"{path.relative_to(source_root)}:{number}: {line.strip()}"
+                    )
+    assert not found, "legacy global RNG calls found:\n" + "\n".join(found)
+
+
+def test_lloyds_points_respect_a_reseed():
+    """The cache is keyed on the seed as well as the shape.
+
+    It is memoised on ``(n, k, n_steps)`` and its result depends on the seed, so
+    keying on the shape alone returned points generated under whichever seed
+    called first.
+    """
+    from optimizers.solution_deck import lloyds_algorithm_points
+
+    set_seed(0)
+    first = lloyds_algorithm_points(4, 2)
+    set_seed(1)
+    second = lloyds_algorithm_points(4, 2)
+    set_seed(0)
+    again = lloyds_algorithm_points(4, 2)
+
+    assert not np.array_equal(first, second), "a reseed must change the points"
+    np.testing.assert_array_equal(first, again)
+
+
+# ---------------------------------------------------------------------------
 # The stream machinery itself
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
> **Stacked on #100.** Base is `claude/deterministic-parallel-seeding`, so this diff shows only the sweep. It reuses `spawn_streams` / `use_stream` from that PR. Retarget to `main` once #100 lands.

## Why this is more than tidying

#100 gave each parallel task its own stream, but that only helps draws that go through `core.random.rng()`. Thirteen call sites still used the legacy `np.random.*` functions — a **separate generator with separate state**. `set_seed` does call `np.random.seed(...)`, so they were reproducible in a single thread, but they cannot participate in a per-task stream, so any of them reached from a worker is unseedable in parallel however the dispatch is wired.

That turned out not to be hypothetical. **The combinatorial TSP solvers build their own `joblib.Parallel` rather than going through `GenerationRunner`**, so #100 never reached them — and all nine of the GA's draws plus both ACOs' were legacy calls. Seeded, `n_jobs=3`, four repeats each:

```
GA    40.634190765, 40.634190765, 40.1237822466, 40.634190765
ACO   34.0806720917, 30.9728421342, 32.3023377661, 32.6706552524
```

Both are deterministic at `n_jobs=1` and 3 after this change.

## What changed

**All thirteen sites converted to `rng()`** — `combinatorial/ga.py` (9), `combinatorial/aco.py`, `combinatorial/aco_mst.py`, `continuous/gd.py`, `solution_deck.py`.

**Four dispatch sites wired to per-task streams** — the three combinatorial ones and gradient descent's restart fan-out — via a new `run_in_stream(generator, fn, *args)` helper, defined at module scope so it pickles for the processes backend.

**A cache bug this surfaced rather than caused.** `lloyds_algorithm_points` is `@lru_cache`d on `(n, k, n_steps)`, but its result depends on the seed. So it returned points generated under whichever seed called first and silently ignored every later `set_seed`:

```python
set_seed(0); a = lloyds_algorithm_points(4, 2)
set_seed(1); b = lloyds_algorithm_points(4, 2)
assert a == b   # passed, before this change
```

Split so the cache key includes the seed.

## The one thing to weigh

**This changes the numbers every converted site produces.** The legacy functions are MT19937; `rng()` is PCG64. Seeded results move — to different arbitrary values, not worse ones. The full suite passes unchanged at both fidelities, but if you have external baselines pinned against seeded TSP output, they will shift.

## Guarding the regression

`test_no_legacy_global_random_calls_remain` greps the package for the pattern, allowing only the seeding machinery itself (`np.random.seed`, the `Generator` / `SeedSequence` / `RandomState` constructors). Grepping is crude, but it is the only check that stays true for code nobody has written yet — a behavioural test can only cover the call sites that exist today.

Reverting only `src/` fails 3 of the new tests (`test_tsp_same_seed_same_result[3-ga]`, the grep, and the Lloyd's cache one), so they test the fix rather than the fixture.

## Checks

- `pytest tests/ --fast` — **147 passed** (139 after #100, 8 new). Full-fidelity run also green (4m27s).
- `black --check` clean, `flake8 ./src ./tests` clean.
- `mypy -p optimizers` — 13 errors, the same pre-existing set as `main`; none in the changed files.

---
_Generated by [Claude Code](https://claude.ai/code/session_01HDQxwmw2NorWmWnEwRm31G)_