### PR TITLE
fix(pso): clamp velocity magnitude instead of decaying it; seed the incumbent as a particle

### DIFF
--- a/src/optimizers/continuous/pso.py
+++ b/src/optimizers/continuous/pso.py
@@ -105,7 +105,7 @@ def run_particles(
         )
 
     # Native PSO path: global best is the archive's top entry (best-first).
-    global_best_position = solution_archive[0, :]
+    global_best_position = np.asarray(solution_archive[0, :], dtype=float)
     global_best_value = solution_values[0]
     # Per-variable domains, used to clamp velocity (constant across the run).
     domains = np.array([v.domain for v in variables])
@@ -117,6 +117,18 @@ def run_particles(
     for d, v in enumerate(variables):
         p_best_pos[:, d] = v.initial_random_values(n_particles, rng=rng)
         p_vel[:, d] = v.initial_random_velocities(n_particles, rng=rng)
+    # Seed one particle directly from the archived incumbent (GitHub #101,
+    # defect 2). Without this, the incumbent -- the archive's current best --
+    # only ever acts as an external attractor (``swarm_best_pos`` below) and
+    # never becomes a particle position itself. Since this routine is
+    # stateless across generations (a fresh uniform draw every call), a warm
+    # start written into the archive before the run never actually enters the
+    # swarm: nothing here ever moves *from* it, only *towards* it. Zero
+    # initial velocity so the seeded particle starts exactly at the incumbent
+    # rather than being displaced before its first update.
+    if n_particles > 0:
+        p_best_pos[0, :] = global_best_position
+        p_vel[0, :] = 0.0
     p_pos = p_best_pos.copy()  # Current Position starts at the initial best
     p_best_val = _eval_batch(p_best_pos)
 
@@ -139,10 +151,17 @@ def run_particles(
             + r_p * cognitive * (p_best_pos - p_pos)
             + social * r_g * (swarm_best_pos[None, :] - p_pos)
         )
-        # Clamp the velocity (same per-dimension ratio clamp as before).
-        p_vel *= np.minimum(
-            np.maximum(p_vel / domains, -velocity_clamp), velocity_clamp
-        )
+        # Clamp the velocity magnitude to a fraction of each variable's domain
+        # (GitHub #101, defect 1). The previous ``p_vel *= clip(p_vel/domains,
+        # -clamp, clamp)`` multiplied the velocity by a clamped *ratio*
+        # instead of clamping it: whenever |v| < domain -- nearly always --
+        # the factor is < 1, so velocity shrinks by that same fraction every
+        # iteration and collapses geometrically to zero within a handful of
+        # steps (measured: ~1e-83 of its initial value by iteration 6 with the
+        # default clamp=0.5), well inside the 10 iterations run per
+        # generation. A real clamp bounds the magnitude instead of decaying it.
+        limit = velocity_clamp * domains
+        p_vel = np.clip(p_vel, -limit, limit)
         # Update the particle position for this time step.
         p_pos += p_vel
         # Evaluate all particles, then update personal/swarm bests vectorized.

--- a/tests/test_pso_issue_101.py
+++ b/tests/test_pso_issue_101.py
@@ -1,0 +1,178 @@
+"""Regression tests for GitHub issue #101.
+
+Two defects in the native PSO path (``continuous/pso.py``):
+
+1. The velocity "clamp" multiplied velocity by a clamped *ratio* instead of
+   clamping its magnitude, so it decayed geometrically to zero within a
+   handful of iterations (well inside the 10 run per generation) -- the
+   swarm effectively froze after its first few moves, every generation.
+2. The archive's incumbent (``solution_archive[0]``) was never seeded as a
+   particle position, only used as an external attractor, so a warm start
+   never actually entered the swarm -- it only ever appeared in the
+   comparison at the end, never as something particles could improve from.
+
+See https://github.com/fundthmcalculus/optimizers/issues/101 for the full
+writeup and reproduction.
+"""
+
+import numpy as np
+import pytest
+
+from optimizers.continuous.base import _ArgProvider
+from optimizers.continuous.pso import (
+    ParticleSwarmOptimizer,
+    ParticleSwarmOptimizerConfig,
+    run_particles,
+)
+from optimizers.continuous.variables import InputContinuousVariable
+from optimizers.core.random import set_seed
+
+
+def _sphere(x):
+    return float(np.sum((x - 5.0) ** 2))
+
+
+def _sphere_batch(x):
+    return np.sum((x - 5.0) ** 2, axis=-1)
+
+
+def test_velocity_clamp_saturates_instead_of_decaying():
+    """The exact repro from the issue: an over-limit velocity should clamp to
+    the limit and stay there, not shrink towards zero on repeated application.
+    """
+    domain, clamp = 10.0, 0.5
+    limit = clamp * domain
+    v = np.array([5.0])  # already above the limit
+    for _ in range(8):
+        v = np.clip(v, -limit, limit)
+        assert v[0] == pytest.approx(limit)
+
+    # And the buggy formula really did collapse geometrically, for contrast
+    # (this is what the fix replaces -- not exercised by the shipped code).
+    v_buggy = np.array([0.5])
+    for _ in range(6):
+        v_buggy = v_buggy * np.minimum(np.maximum(v_buggy / domain, -clamp), clamp)
+    assert abs(v_buggy[0]) < 1e-10  # collapsed to ~5.4e-83 by this point
+
+
+def test_incumbent_is_seeded_as_a_particle():
+    """``run_particles`` must place the archive's best entry into the swarm as
+    a real particle position (issue #101 defect 2), not just use it as an
+    external attractor.
+
+    The directly testable, seed-independent guarantee this gives: the
+    returned population's best *personal-best* value can never be worse than
+    the incumbent's own value, because one particle's personal best starts
+    there and personal bests only ever improve (``p_best_val = np.where
+    (improved, new_vals, p_best_val)``). Before the fix, every particle
+    started at an unrelated random draw, so nothing guaranteed the returned
+    population would contain (or beat) the incumbent at all within one
+    generation.
+    """
+    n_dim = 5
+    variables = [
+        InputContinuousVariable(f"x{i}", -1000.0, 1000.0) for i in range(n_dim)
+    ]
+    incumbent = np.full(n_dim, 5.0) + 2.0
+    incumbent_value = _sphere(incumbent)
+    archive = np.tile(incumbent, (20, 1))  # irrelevant filler rows
+    archive[0] = incumbent
+    values = np.full(20, 1e9)
+    values[0] = incumbent_value
+
+    qd = (
+        False,
+        "native",
+        0.01,
+        0.2,
+        np.array([-1000.0] * n_dim),
+        np.array([1000.0] * n_dim),
+    )
+    for seed in range(5):
+        set_seed(seed)
+        fixed = (
+            _ArgProvider(),
+            variables,
+            _sphere,
+            0.5,
+            1.5,
+            1.5,
+            0.5,
+            16,
+            "none",
+            qd,
+            _sphere_batch,
+        )
+        out = run_particles(fixed, {}, archive, values)
+        assert out.population_values.min() <= incumbent_value + 1e-9, (
+            f"seed={seed}: nothing in the returned population reached the "
+            "incumbent's own value -- it was never actually a particle"
+        )
+
+
+def test_pso_makes_real_progress_without_freezing():
+    """End-to-end: a wide-domain, no-warm-start run must land far better than
+    a frozen swarm (which behaves like a handful of near-random draws per
+    generation). Measured before this fix: ~2e5-5e5 over 3 seeds on this
+    exact setup; after: ~2.6e3-3.9e3. The threshold below is a wide margin
+    between the two, so it fails if the multiplicative-decay bug regresses.
+    """
+    n_dim = 10
+    variables = [
+        InputContinuousVariable(f"x{i}", -1000.0, 1000.0) for i in range(n_dim)
+    ]
+
+    for seed in range(3):
+        set_seed(seed)
+        config = ParticleSwarmOptimizerConfig(
+            name="progress-check",
+            population_size=30,
+            num_generations=50,
+            solution_archive_size=100,
+            n_jobs=1,
+            joblib_prefer="threads",
+            local_grad_optim="none",
+            stop_after_iterations=1000,
+        )
+        optimizer = ParticleSwarmOptimizer(
+            config=config, variables=variables, fcn=_sphere, batch_fcn=_sphere_batch
+        )
+        result = optimizer.solve()
+        assert result.solution_score < 50_000, (
+            f"seed={seed}: PSO only reached {result.solution_score:.1f}, consistent "
+            "with a frozen swarm behaving like near-random search"
+        )
+
+
+def test_warm_started_incumbent_never_regresses():
+    """A warm-started run must never report a worse score than the incumbent
+    it was seeded with -- the elitist archive already guarantees this
+    independent of the PSO internals, but it's worth pinning given how easy
+    it would be for a future change to the seeded particle's handling to
+    accidentally drop it from the archive.
+    """
+    n_dim = 5
+    variables = [
+        InputContinuousVariable(f"x{i}", -1000.0, 1000.0) for i in range(n_dim)
+    ]
+
+    for seed in range(3):
+        set_seed(seed)
+        config = ParticleSwarmOptimizerConfig(
+            name="no-regress",
+            population_size=20,
+            num_generations=10,
+            solution_archive_size=60,
+            n_jobs=1,
+            joblib_prefer="threads",
+            local_grad_optim="none",
+            stop_after_iterations=1000,
+        )
+        optimizer = ParticleSwarmOptimizer(
+            config=config, variables=variables, fcn=_sphere
+        )
+        incumbent = np.full(n_dim, 5.0) + 2.0
+        optimizer.soln_deck.solution_archive[0] = incumbent
+        optimizer.soln_deck.solution_value[0] = _sphere(incumbent)
+        result = optimizer.solve(preserve_percent=1.0 / config.solution_archive_size)
+        assert result.solution_score <= _sphere(incumbent) + 1e-9


### PR DESCRIPTION
## Summary

Fixes #101 — two defects in the native PSO path (`continuous/pso.py`), both diagnosed in the issue:

1. **Velocity clamp was a multiply, not a clamp.** `p_vel *= clip(p_vel/domains, -clamp, clamp)` shrinks velocity by that ratio every iteration whenever `|v| < domain` (nearly always), collapsing geometrically to ~0 within a handful of steps — well inside the 10 iterations run per generation. The swarm effectively froze after its first few moves, every generation. Replaced with an actual clamp: `p_vel = np.clip(p_vel, -velocity_clamp * domains, velocity_clamp * domains)`.
2. **The incumbent was never a particle.** `solution_archive[0]` was only ever used as an external attractor (`swarm_best_pos`), never seeded as a particle position. Since `run_particles` is stateless across generations (fresh uniform draw every call, by design), a warm start never actually entered the swarm. Now one particle is seeded at the incumbent each generation (zero initial velocity).

Together these explain the reported symptom exactly: from a good warm start, every particle started elsewhere and froze within a few steps, so nothing ever had a chance to reach (let alone beat) the incumbent — PSO returned it unchanged while GA/ACO (whose operators consume archive members directly) kept improving.

**Stacked on #102** (this branch's base is `claude/optimize-ga-aco-pso-perf-qbl90y`, not `main`) since it builds on the batched-evaluation plumbing landed there (`_ArgProvider`, `run_particles`'s `batch_fcn` path). Should merge after #102.

## Verification

- The issue's exact numeric repro now saturates instead of decaying to ~1e-83 of its initial value.
- A direct `run_particles` check confirms the incumbent's value is always reachable within one generation after the fix (5/5 seeds); a reconstruction of the pre-fix code fails the same check 5/5 seeds.
- End-to-end, a no-warm-start run on a wide-domain sphere lands ~2.6e3–3.9e3 across 3 seeds after the fix vs. ~2.1e5–4.6e5 before (reconstructed pre-fix code) — consistent with "frozen swarm behaves like near-random search".
- Full suite: 153 tests pass (149 existing + 4 new regression tests in `tests/test_pso_issue_101.py`).

## Test plan

- [x] `pytest tests/test_pso_issue_101.py -v` — new regression tests (velocity clamp saturation, incumbent-seeded-as-particle, end-to-end progress, no-regression on warm start)
- [x] `pytest tests/ --fast -q` — full suite green (153 passed)
- [x] `black --check` / `flake8` / `mypy` — clean (no new errors vs. baseline)
- [x] Verified against a reconstruction of the pre-fix code to confirm the new tests actually discriminate old vs. new behavior

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_01PL1RQAMygmBYkWz3rB31uN


---
_Generated by [Claude Code](https://claude.ai/code/session_01PL1RQAMygmBYkWz3rB31uN)_