### PR TITLE
Enforce keyword-only arguments in optimizer constructors

### DIFF
--- a/sample.py
+++ b/sample.py
@@ -29,8 +29,8 @@ def main():
     )
     optimizer = AntColonyOptimizer(
         config=config,
-        variables=input_variables,
         fcn=optim_ackley,
+        variables=input_variables,
     )
 
     # Process-based execution

--- a/src/optimizers/combinatorial/aco.py
+++ b/src/optimizers/combinatorial/aco.py
@@ -33,6 +33,7 @@ class AntColonyTSPConfig(IOptimizerConfig):
 class AntColonyTSP(TSPBase):
     def __init__(
         self,
+        *,
         config: AntColonyTSPConfig,
         network_routes: Optional[AF] = None,
         city_locations: Optional[AF] = None,

--- a/src/optimizers/combinatorial/aco.py
+++ b/src/optimizers/combinatorial/aco.py
@@ -128,7 +128,7 @@ class AntColonyTSP(TSPBase):
                 back_to_start=self.config.back_to_start, name=self.config.name
             )
             two_opt_optimize = TwoOptTSP(
-                two_opt_config,
+                config=two_opt_config,
                 initial_route=optimal_city_order,
                 initial_value=optimal_tour_length,
                 network_routes=self.network_routes,

--- a/src/optimizers/combinatorial/compare.py
+++ b/src/optimizers/combinatorial/compare.py
@@ -54,24 +54,24 @@ def _warmup(distances: AF, backend: LocalSearchBackend) -> None:
     n = min(6, distances.shape[0])
     d = np.ascontiguousarray(distances[:n, :n])
     seed = NearestNeighborTSP(
-        NearestNeighborTSPConfig(name="w"), network_routes=d.copy()
+        config=NearestNeighborTSPConfig(name="w"), network_routes=d.copy()
     ).solve()
     seed_route = cast(AI, np.ascontiguousarray(seed.optimal_path))
     seed_value = seed.optimal_value
     TwoOptTSP(
-        TwoOptTSPConfig(name="w", local_search_backend=backend),
+        config=TwoOptTSPConfig(name="w", local_search_backend=backend),
         network_routes=d.copy(),
         initial_route=seed_route.copy(),
         initial_value=seed_value,
     ).solve()
     ThreeOptTSP(
-        TwoOptTSPConfig(name="w", num_iterations=1, local_search_backend=backend),
+        config=TwoOptTSPConfig(name="w", num_iterations=1, local_search_backend=backend),
         network_routes=d.copy(),
         initial_route=seed_route.copy(),
         initial_value=seed_value,
     ).solve()
     LinKernighanTSP(
-        LinKernighanTSPConfig(name="w", local_search_backend=backend),
+        config=LinKernighanTSPConfig(name="w", local_search_backend=backend),
         network_routes=d.copy(),
         initial_route=seed_route.copy(),
         initial_value=seed_value,
@@ -102,7 +102,7 @@ def compare_tsp_heuristics(
 
     t0 = time.perf_counter()
     nn = NearestNeighborTSP(
-        NearestNeighborTSPConfig(name="nn", back_to_start=back_to_start),
+        config=NearestNeighborTSPConfig(name="nn", back_to_start=back_to_start),
         network_routes=distances.copy(),
     ).solve()
     records.append(("Nearest Neighbor", nn, time.perf_counter() - t0))
@@ -112,7 +112,7 @@ def compare_tsp_heuristics(
     def _timed(cls: Any, config: Any) -> tuple[CombinatoricsResult, float]:
         t = time.perf_counter()
         result = cls(
-            config,
+            config=config,
             initial_route=seed_route.copy(),
             initial_value=seed_val,
             network_routes=distances.copy(),

--- a/src/optimizers/combinatorial/compare.py
+++ b/src/optimizers/combinatorial/compare.py
@@ -65,7 +65,9 @@ def _warmup(distances: AF, backend: LocalSearchBackend) -> None:
         initial_value=seed_value,
     ).solve()
     ThreeOptTSP(
-        config=TwoOptTSPConfig(name="w", num_iterations=1, local_search_backend=backend),
+        config=TwoOptTSPConfig(
+            name="w", num_iterations=1, local_search_backend=backend
+        ),
         network_routes=d.copy(),
         initial_route=seed_route.copy(),
         initial_value=seed_value,

--- a/src/optimizers/combinatorial/ga.py
+++ b/src/optimizers/combinatorial/ga.py
@@ -30,6 +30,7 @@ class GeneticAlgorithmTSPConfig(IOptimizerConfig):
 class GeneticAlgorithmTSP(TSPBase):
     def __init__(
         self,
+        *,
         config: GeneticAlgorithmTSPConfig,
         network_routes: Optional[AF] = None,
         city_locations: Optional[AF] = None,

--- a/src/optimizers/combinatorial/ga.py
+++ b/src/optimizers/combinatorial/ga.py
@@ -126,7 +126,7 @@ class GeneticAlgorithmTSP(TSPBase):
                 back_to_start=self.config.back_to_start, name=self.config.name
             )
             two_opt_optimize = TwoOptTSP(
-                two_opt_config,
+                config=two_opt_config,
                 initial_route=genome[0, :],
                 initial_value=genome_value[0],
                 network_routes=self.network_routes,

--- a/src/optimizers/combinatorial/mtsp.py
+++ b/src/optimizers/combinatorial/mtsp.py
@@ -81,7 +81,7 @@ class AntColonyMTSP:
             cluster_cities = self.city_locations[cluster, :]
             cluster_config = create_from_dict(self.config.__dict__, AntColonyTSPConfig)
             cluster_config.name = f"{self.config.name}-{cluster_id + 1}"
-            tsp_solve = AntColonyTSP(cluster_config, city_locations=cluster_cities)
+            tsp_solve = AntColonyTSP(config=cluster_config, city_locations=cluster_cities)
             cluster_result = tsp_solve.solve()
             # Map cluster indices back to original indices
             cluster_result.optimal_path = np.array(

--- a/src/optimizers/combinatorial/mtsp.py
+++ b/src/optimizers/combinatorial/mtsp.py
@@ -56,7 +56,7 @@ class AntColonyMTSP:
                     continue
                 tsp_config.name = f"{tsp_config.name}-{cluster_id + 1}"
                 tsp_solve = AntColonyTSP(
-                    tsp_config,
+                    config=tsp_config,
                     city_locations=cluster_cities,
                 )
                 tsp_result = tsp_solve.solve()
@@ -81,7 +81,9 @@ class AntColonyMTSP:
             cluster_cities = self.city_locations[cluster, :]
             cluster_config = create_from_dict(self.config.__dict__, AntColonyTSPConfig)
             cluster_config.name = f"{self.config.name}-{cluster_id + 1}"
-            tsp_solve = AntColonyTSP(config=cluster_config, city_locations=cluster_cities)
+            tsp_solve = AntColonyTSP(
+                config=cluster_config, city_locations=cluster_cities
+            )
             cluster_result = tsp_solve.solve()
             # Map cluster indices back to original indices
             cluster_result.optimal_path = np.array(

--- a/src/optimizers/combinatorial/strategy.py
+++ b/src/optimizers/combinatorial/strategy.py
@@ -449,7 +449,7 @@ class TwoOptTSP(TSPBase):
                 back_to_start=self.config.back_to_start, name=self.config.name
             )
             nn_solver = NearestNeighborTSP(
-                nn_config,
+                config=nn_config,
                 network_routes=self.network_routes,
                 city_locations=self.city_locations,
             )

--- a/src/optimizers/combinatorial/strategy.py
+++ b/src/optimizers/combinatorial/strategy.py
@@ -384,6 +384,7 @@ def _lk_kernel(distances: AF, tour: AI, cand: AI, max_passes: int) -> int:  # no
 class TwoOptTSP(TSPBase):
     def __init__(
         self,
+        *,
         config: TwoOptTSPConfig,
         network_routes: Optional[AF] = None,
         city_locations: Optional[AF] = None,
@@ -464,6 +465,7 @@ class TwoOptTSP(TSPBase):
 class ThreeOptTSP(TwoOptTSP):
     def __init__(
         self,
+        *,
         config: TwoOptTSPConfig,
         initial_route: Optional[AI] = None,
         initial_value: Optional[F] = None,
@@ -471,7 +473,7 @@ class ThreeOptTSP(TwoOptTSP):
         city_locations: Optional[AF] = None,
     ):
         super().__init__(
-            config,
+            config=config,
             initial_route=initial_route,
             initial_value=initial_value,
             network_routes=network_routes,
@@ -596,6 +598,7 @@ class NearestNeighborTSPConfig(IOptimizerConfig):
 class NearestNeighborTSP(TSPBase):
     def __init__(
         self,
+        *,
         config: NearestNeighborTSPConfig,
         network_routes: Optional[AF] = None,
         city_locations: Optional[AF] = None,
@@ -654,6 +657,7 @@ class ConvexHullTSPConfig(IOptimizerConfig):
 class ConvexHullTSP(TSPBase):
     def __init__(
         self,
+        *,
         config: ConvexHullTSPConfig,
         network_routes: Optional[AF] = None,
         city_locations: Optional[AF] = None,

--- a/src/optimizers/continuous/aco.py
+++ b/src/optimizers/continuous/aco.py
@@ -118,6 +118,7 @@ def run_ants(
 class AntColonyOptimizer(IOptimizer):
     def __init__(
         self,
+        *,
         config: IOptimizerConfig,
         fcn: GoalFcn,
         variables: InputVariables,
@@ -126,12 +127,12 @@ class AntColonyOptimizer(IOptimizer):
         batch_fcn: BatchGoalFcn | None = None,
     ):
         super().__init__(
-            config,
-            fcn,
-            variables,
-            args,
-            existing_soln_deck,
-            batch_fcn,
+            config=config,
+            fcn=fcn,
+            variables=variables,
+            args=args,
+            existing_soln_deck=existing_soln_deck,
+            batch_fcn=batch_fcn,
         )
         self.config: AntColonyOptimizerConfig = AntColonyOptimizerConfig(
             **{**config.__dict__}

--- a/src/optimizers/continuous/base.py
+++ b/src/optimizers/continuous/base.py
@@ -137,6 +137,7 @@ class IOptimizer(abc.ABC):
 
     def __init__(
         self,
+        *,
         config: IOptimizerConfig,
         fcn: GoalFcn,
         variables: InputVariables,

--- a/src/optimizers/continuous/ga.py
+++ b/src/optimizers/continuous/ga.py
@@ -198,6 +198,7 @@ def run_ga(
 class GeneticAlgorithmOptimizer(IOptimizer):
     def __init__(
         self,
+        *,
         config: IOptimizerConfig,
         fcn: GoalFcn,
         variables: InputVariables,
@@ -206,12 +207,12 @@ class GeneticAlgorithmOptimizer(IOptimizer):
         batch_fcn: BatchGoalFcn | None = None,
     ):
         super().__init__(
-            config,
-            fcn,
-            variables,
-            args,
-            existing_soln_deck,
-            batch_fcn,
+            config=config,
+            fcn=fcn,
+            variables=variables,
+            args=args,
+            existing_soln_deck=existing_soln_deck,
+            batch_fcn=batch_fcn,
         )
         self.config: GeneticAlgorithmOptimizerConfig = GeneticAlgorithmOptimizerConfig(
             **{**config.__dict__}

--- a/src/optimizers/continuous/gd.py
+++ b/src/optimizers/continuous/gd.py
@@ -110,6 +110,7 @@ def _count_discrete_vars(variables: InputVariables) -> tuple[int, list[int]]:
 class GradientDescentOptimizer(IOptimizer):
     def __init__(
         self,
+        *,
         config: IOptimizerConfig,
         fcn: GoalFcn,
         variables: InputVariables,
@@ -117,10 +118,10 @@ class GradientDescentOptimizer(IOptimizer):
         nested: bool = False,
     ):
         super().__init__(
-            config,
-            fcn,
-            variables,
-            args,
+            config=config,
+            fcn=fcn,
+            variables=variables,
+            args=args,
         )
         self.config: GradientDescentOptimizerConfig = GradientDescentOptimizerConfig(
             **{**config.__dict__}

--- a/src/optimizers/continuous/optimizer_strategy.py
+++ b/src/optimizers/continuous/optimizer_strategy.py
@@ -72,6 +72,7 @@ class RandomOptimizerSelection(IOptimizerSelection):
 class MultiTypeOptimizer(IOptimizer):
     def __init__(
         self,
+        *,
         config: IOptimizerConfig,
         fcn: GoalFcn,
         variables: InputVariables,
@@ -79,7 +80,12 @@ class MultiTypeOptimizer(IOptimizer):
         initial_optimizer: OptimizationType = "aco",
         optimizer_selector: IOptimizerSelection = RandomOptimizerSelection(),
     ):
-        super().__init__(config, fcn, variables, args)
+        super().__init__(
+            config=config,
+            fcn=fcn,
+            variables=variables,
+            args=args,
+        )
         self.initial_optimizer = initial_optimizer
         self.optimizer_selector = optimizer_selector
         self.fcn = fcn
@@ -111,21 +117,34 @@ class MultiTypeOptimizer(IOptimizer):
         optimizer: IOptimizer
         if selected_type == "aco":
             optimizer = AntColonyOptimizer(
-                converted_config, self.fcn, self.variables, self.args
+                config=converted_config,
+                fcn=self.fcn,
+                variables=self.variables,
+                args=self.args,
             )
         elif selected_type == "pso":
             optimizer = ParticleSwarmOptimizer(
-                converted_config, self.fcn, self.variables, self.args
+                config=converted_config,
+                fcn=self.fcn,
+                variables=self.variables,
+                args=self.args,
             )
         elif selected_type == "ga":
             optimizer = GeneticAlgorithmOptimizer(
-                converted_config, self.fcn, self.variables, self.args
+                config=converted_config,
+                fcn=self.fcn,
+                variables=self.variables,
+                args=self.args,
             )
         elif selected_type == "gd":
             # Nested local search: this strategy owns the higher-level search, so
             # GD runs serially (see GradientDescentOptimizer's ``nested`` flag).
             optimizer = GradientDescentOptimizer(
-                converted_config, self.fcn, self.variables, self.args, nested=True
+                config=converted_config,
+                fcn=self.fcn,
+                variables=self.variables,
+                args=self.args,
+                nested=True,
             )
         else:
             # Should be unreachable due to ensure_literal_choice
@@ -167,12 +186,18 @@ class GroupedVariableOptimizerConfig(IOptimizerConfig):
 class GroupedVariableOptimizer(IOptimizer):
     def __init__(
         self,
+        *,
         config: GroupedVariableOptimizerConfig,
         fcn: GoalFcn,
         variables: InputVariables,
         args: InputArguments | None = None,
     ):
-        super().__init__(config, fcn, variables, args)
+        super().__init__(
+            config=config,
+            fcn=fcn,
+            variables=variables,
+            args=args,
+        )
         self.config: GroupedVariableOptimizerConfig = config
         if config.groups is None:
             raise ValueError("Group order and groups must be provided")
@@ -203,17 +228,23 @@ class GroupedVariableOptimizer(IOptimizer):
                 config = config_to_type(self.config, group.optimizer_type)
                 optim: IOptimizer
                 if group.optimizer_type == "aco":
-                    optim = AntColonyOptimizer(config, new_fcn, group_vars)
+                    optim = AntColonyOptimizer(
+                        config=config, fcn=new_fcn, variables=group_vars
+                    )
                 elif group.optimizer_type == "pso":
-                    optim = ParticleSwarmOptimizer(config, new_fcn, group_vars)
+                    optim = ParticleSwarmOptimizer(
+                        config=config, fcn=new_fcn, variables=group_vars
+                    )
                 elif group.optimizer_type == "ga":
-                    optim = GeneticAlgorithmOptimizer(config, new_fcn, group_vars)
+                    optim = GeneticAlgorithmOptimizer(
+                        config=config, fcn=new_fcn, variables=group_vars
+                    )
                 elif group.optimizer_type == "gd":
                     # Nested local search: the grouped optimizer owns the outer
                     # loop over groups/rounds, so GD runs serially (see its
                     # ``nested`` flag).
                     optim = GradientDescentOptimizer(
-                        config, new_fcn, group_vars, nested=True
+                        config=config, fcn=new_fcn, variables=group_vars, nested=True
                     )
                 else:
                     raise NotImplementedError("Optimizer not implemented")

--- a/src/optimizers/continuous/pso.py
+++ b/src/optimizers/continuous/pso.py
@@ -203,6 +203,7 @@ def run_particles(
 class ParticleSwarmOptimizer(IOptimizer):
     def __init__(
         self,
+        *,
         config: IOptimizerConfig,
         fcn: GoalFcn,
         variables: InputVariables,
@@ -211,12 +212,12 @@ class ParticleSwarmOptimizer(IOptimizer):
         batch_fcn: BatchGoalFcn | None = None,
     ):
         super().__init__(
-            config,
-            fcn,
-            variables,
-            args,
-            existing_soln_deck,
-            batch_fcn,
+            config=config,
+            fcn=fcn,
+            variables=variables,
+            args=args,
+            existing_soln_deck=existing_soln_deck,
+            batch_fcn=batch_fcn,
         )
         self.config: ParticleSwarmOptimizerConfig = ParticleSwarmOptimizerConfig(
             **{**config.__dict__}

--- a/src/optimizers/continuous/step.py
+++ b/src/optimizers/continuous/step.py
@@ -21,6 +21,7 @@ class StepWiseOptimizerConfig(IOptimizerConfig):
 class StepWiseOptimizer(IOptimizer):
     def __init__(
         self,
+        *,
         config: IOptimizerConfig,
         fcn: GoalFcn,
         variables: InputVariables,
@@ -28,11 +29,11 @@ class StepWiseOptimizer(IOptimizer):
         existing_soln_deck: SolutionDeck | None = None,
     ):
         super().__init__(
-            config,
-            fcn,
-            variables,
-            args,
-            existing_soln_deck,
+            config=config,
+            fcn=fcn,
+            variables=variables,
+            args=args,
+            existing_soln_deck=existing_soln_deck,
         )
         self.config: StepWiseOptimizerConfig = StepWiseOptimizerConfig(
             **{**config.__dict__}

--- a/tests/test_checkpointing.py
+++ b/tests/test_checkpointing.py
@@ -40,7 +40,7 @@ def simple_ga_setup():
 
 def test_save_and_load_checkpoint_single_run(tmp_path: Path, simple_ga_setup):
     fcn, variables, cfg = simple_ga_setup
-    opt = GeneticAlgorithmOptimizer(cfg, fcn, variables)
+    opt = GeneticAlgorithmOptimizer(config=cfg, fcn=fcn, variables=variables)
     res = opt.solve()
 
     # Save checkpoint
@@ -78,7 +78,7 @@ def test_run_multiple_and_summary_and_plot(
     def build_optimizer():
         # Fresh config/optimizer per run
         cfg = GeneticAlgorithmOptimizerConfig(**{**base_cfg.__dict__})
-        opt = GeneticAlgorithmOptimizer(cfg, fcn, variables)
+        opt = GeneticAlgorithmOptimizer(config=cfg, fcn=fcn, variables=variables)
 
         def runner():
             result = opt.solve()

--- a/tests/test_combinatorics.py
+++ b/tests/test_combinatorics.py
@@ -228,7 +228,7 @@ def test_aco_local_optimize_respects_back_to_start(back_to_start):
         local_optimize=True,
     )
     optimizer = AntColonyTSP(
-        config, network_routes=distances, city_locations=all_cities
+        config=config, network_routes=distances, city_locations=all_cities
     )
     result = optimizer.solve()
 

--- a/tests/test_combinatorics.py
+++ b/tests/test_combinatorics.py
@@ -100,7 +100,7 @@ def test_aco_mst():
         joblib_prefer="threads",
     )
     optimizer = AntColonyTSP(
-        config, network_routes=distances, city_locations=all_cities
+        config=config, network_routes=distances, city_locations=all_cities
     )
     result = optimizer.solve()
     plot_convergence(result.value_history)
@@ -120,7 +120,7 @@ def test_aco_tsp():
         joblib_prefer="threads",
     )
     optimizer = AntColonyTSP(
-        config, network_routes=distances, city_locations=all_cities
+        config=config, network_routes=distances, city_locations=all_cities
     )
     result = optimizer.solve()
     plot_convergence(result.value_history)
@@ -139,7 +139,7 @@ def test_ga_tsp():
         joblib_prefer="threads",
     )
     optimizer = GeneticAlgorithmTSP(
-        config, network_routes=distances, city_locations=all_cities
+        config=config, network_routes=distances, city_locations=all_cities
     )
     result = optimizer.solve()
     plot_convergence(result.value_history)
@@ -152,11 +152,11 @@ def test_nn_tsp():
     distances: AF = pairwise_distances(all_cities)
     # Compute TSP optimized distance
     config = NearestNeighborTSPConfig(name="Test NN", back_to_start=True)
-    optimizer = NearestNeighborTSP(config, distances)
+    optimizer = NearestNeighborTSP(config=config, network_routes=distances)
     result = optimizer.solve()
     topt_config = TwoOptTSPConfig(name="2opt TSP", back_to_start=True)
     topt_optimizer = TwoOptTSP(
-        topt_config,
+        config=topt_config,
         initial_route=result.optimal_path,
         initial_value=result.optimal_value,
         network_routes=distances,
@@ -166,7 +166,7 @@ def test_nn_tsp():
         name="2opt TSP", back_to_start=True, nearest_neighbors=5
     )
     topt_optimizer2 = ThreeOptTSP(
-        topt_config2,
+        config=topt_config2,
         initial_route=result.optimal_path,
         initial_value=result.optimal_value,
         network_routes=distances,
@@ -197,7 +197,7 @@ def test_ga_local_optimize_respects_back_to_start(back_to_start):
         local_optimize=True,
     )
     optimizer = GeneticAlgorithmTSP(
-        config, network_routes=distances, city_locations=all_cities
+        config=config, network_routes=distances, city_locations=all_cities
     )
     result = optimizer.solve()
 
@@ -244,7 +244,7 @@ def test_convex_hull_tsp():
     all_cities = circle_random_clusters()
     # Compute TSP optimized distance
     config = ConvexHullTSPConfig(name="Test Convex Hull", back_to_start=True)
-    optimizer = ConvexHullTSP(config, city_locations=all_cities)
+    optimizer = ConvexHullTSP(config=config, city_locations=all_cities)
     result = optimizer.solve()
     plot_cities_and_route(all_cities, result.optimal_path)
 

--- a/tests/test_determinism.py
+++ b/tests/test_determinism.py
@@ -74,7 +74,7 @@ def solve_once(kind, *, seed=0, n_jobs=1, prefer="threads", local_grad_optim="no
         contextlib.redirect_stdout(io.StringIO()),
         contextlib.redirect_stderr(io.StringIO()),
     ):
-        result = optimizer_cls(config, goal, variables).solve()
+        result = optimizer_cls(config=config, fcn=goal, variables=variables).solve()
     return round(float(result.solution_score), 12), len(evaluations)
 
 

--- a/tests/test_map_elites.py
+++ b/tests/test_map_elites.py
@@ -51,7 +51,7 @@ def test_all_solvers_map_elites(opt_cls, cfg_cls, variation):
         qd_variation=variation,
         stop_after_iterations=999,
     )
-    opt = opt_cls(cfg, _sphere, _vars(), args={})
+    opt = opt_cls(config=cfg, fcn=_sphere, variables=_vars(), args={})
     opt.solve()
     assert isinstance(opt.soln_deck, CVTArchive)
     assert opt.soln_deck.coverage > 0.2

--- a/tests/test_map_elites.py
+++ b/tests/test_map_elites.py
@@ -169,7 +169,7 @@ def test_ga_map_elites_end_to_end_builds_cvt_and_covers():
         archive_cells=32,
         stop_after_iterations=999,
     )
-    opt = GeneticAlgorithmOptimizer(cfg, _sphere, _vars(), args={})
+    opt = GeneticAlgorithmOptimizer(config=cfg, fcn=_sphere, variables=_vars(), args={})
     res = opt.solve()
     assert isinstance(opt.soln_deck, CVTArchive)
     assert opt.soln_deck.coverage > 0.2
@@ -192,7 +192,7 @@ def test_ga_map_elites_iso_line_variation_runs():
         qd_variation="iso_line",
         stop_after_iterations=999,
     )
-    opt = GeneticAlgorithmOptimizer(cfg, _sphere, _vars(), args={})
+    opt = GeneticAlgorithmOptimizer(config=cfg, fcn=_sphere, variables=_vars(), args={})
     opt.solve()
     assert opt.soln_deck.coverage > 0.2
 
@@ -210,7 +210,7 @@ def test_aco_map_elites_end_to_end():
         archive_cells=32,
         stop_after_iterations=999,
     )
-    opt = AntColonyOptimizer(cfg, _sphere, _vars(), args={})
+    opt = AntColonyOptimizer(config=cfg, fcn=_sphere, variables=_vars(), args={})
     opt.solve()
     assert isinstance(opt.soln_deck, CVTArchive)
     assert opt.soln_deck.coverage > 0.0
@@ -225,7 +225,7 @@ def test_scalar_mode_uses_solution_deck_not_cvt():
         n_jobs=1,
         joblib_prefer="threads",
     )
-    opt = GeneticAlgorithmOptimizer(cfg, _sphere, _vars(), args={})
+    opt = GeneticAlgorithmOptimizer(config=cfg, fcn=_sphere, variables=_vars(), args={})
     opt.solve()
     assert isinstance(opt.soln_deck, SolutionDeck)
     assert not isinstance(opt.soln_deck, CVTArchive)
@@ -244,7 +244,7 @@ def test_outputs_descriptor_source_not_yet_supported():
         n_outputs=2,
     )
     try:
-        GeneticAlgorithmOptimizer(cfg, _sphere, _vars(), args={})
+        GeneticAlgorithmOptimizer(config=cfg, fcn=_sphere, variables=_vars(), args={})
         raise AssertionError("expected NotImplementedError for outputs source")
     except NotImplementedError:
         pass

--- a/tests/test_multi_output.py
+++ b/tests/test_multi_output.py
@@ -83,7 +83,9 @@ def test_scalar_mode_bit_identical_to_untracked_config():
             joblib_prefer="threads",
             solution_archive_size=20,
         )
-        return GeneticAlgorithmOptimizer(config=cfg, fcn=_sphere, variables=_vars(), args={}).solve()
+        return GeneticAlgorithmOptimizer(
+            config=cfg, fcn=_sphere, variables=_vars(), args={}
+        ).solve()
 
     a, b = run(), run()
     assert a.solution_score == b.solution_score

--- a/tests/test_multi_output.py
+++ b/tests/test_multi_output.py
@@ -51,7 +51,7 @@ def test_scalar_mode_tracks_nothing():
         joblib_prefer="threads",
         solution_archive_size=20,
     )
-    opt = GeneticAlgorithmOptimizer(cfg, _sphere, _vars(), args={})
+    opt = GeneticAlgorithmOptimizer(config=cfg, fcn=_sphere, variables=_vars(), args={})
     opt.solve()
     assert opt.soln_deck.solution_outputs is None
 
@@ -83,7 +83,7 @@ def test_scalar_mode_bit_identical_to_untracked_config():
             joblib_prefer="threads",
             solution_archive_size=20,
         )
-        return GeneticAlgorithmOptimizer(cfg, _sphere, _vars(), args={}).solve()
+        return GeneticAlgorithmOptimizer(config=cfg, fcn=_sphere, variables=_vars(), args={}).solve()
 
     a, b = run(), run()
     assert a.solution_score == b.solution_score

--- a/tests/test_optimizers.py
+++ b/tests/test_optimizers.py
@@ -209,9 +209,13 @@ def test_gd_nested_flag_forces_serial():
         joblib_prefer="processes",
         parallel_discrete_search=True,
     )
-    standalone = GradientDescentOptimizer(cfg, optim_ackley, variables)
+    standalone = GradientDescentOptimizer(
+        config=cfg, fcn=optim_ackley, variables=variables
+    )
     assert standalone.config.n_jobs == 4  # top-level GD keeps its parallelism
-    nested = GradientDescentOptimizer(cfg, optim_ackley, variables, nested=True)
+    nested = GradientDescentOptimizer(
+        config=cfg, fcn=optim_ackley, variables=variables, nested=True
+    )
     assert nested.config.n_jobs == 1  # nested GD is forced serial
 
 

--- a/tests/test_qd_metrics.py
+++ b/tests/test_qd_metrics.py
@@ -88,7 +88,7 @@ def test_qd_report_map_elites_no_objectives():
         archive_cells=32,
         stop_after_iterations=999,
     )
-    opt = GeneticAlgorithmOptimizer(cfg, _sphere, _vars(), args={})
+    opt = GeneticAlgorithmOptimizer(config=cfg, fcn=_sphere, variables=_vars(), args={})
     opt.solve()
     rep = opt.qd_report()
     assert isinstance(rep, QDReport)
@@ -113,7 +113,7 @@ def test_qd_report_with_tracked_objectives_has_pareto_front():
         n_outputs=2,
         stop_after_iterations=999,
     )
-    opt = GeneticAlgorithmOptimizer(cfg, _biobj, _vars(8), args={})
+    opt = GeneticAlgorithmOptimizer(config=cfg, fcn=_biobj, variables=_vars(8), args={})
     opt.solve()
     rep = opt.qd_report()
     assert rep.all_objectives is not None
@@ -145,7 +145,7 @@ def test_qd_plots_build():
         archive_cells=24,
         stop_after_iterations=999,
     )
-    opt = GeneticAlgorithmOptimizer(cfg, _sphere, _vars(), args={})
+    opt = GeneticAlgorithmOptimizer(config=cfg, fcn=_sphere, variables=_vars(), args={})
     opt.solve()
     fig2 = plot_map_elites(opt.soln_deck)
     assert fig2.axes and fig2.axes[0].collections

--- a/tests/test_runtime_args.py
+++ b/tests/test_runtime_args.py
@@ -69,9 +69,9 @@ def test_metadata_injection_into_goal_and_constraints(tiny_ga_cfg):
     ]
 
     opt = GeneticAlgorithmOptimizer(
-        tiny_ga_cfg,
-        obj,
-        variables,
+        config=tiny_ga_cfg,
+        fcn=obj,
+        variables=variables,
         args=user_args,
     )
 
@@ -212,7 +212,7 @@ def test_eval_count_global_under_processes_backend(monkeypatch):
         InputContinuousVariable("x0", -5.0, 5.0),
         InputContinuousVariable("x1", -5.0, 5.0),
     ]
-    opt = GeneticAlgorithmOptimizer(cfg, obj, variables)
+    opt = GeneticAlgorithmOptimizer(config=cfg, fcn=obj, variables=variables)
     # Guard: the process backend must actually be in effect for this to be a
     # meaningful test (fast mode would otherwise silently downgrade to threads).
     assert opt.config.joblib_prefer == "processes"

--- a/tests/test_tsp_compare.py
+++ b/tests/test_tsp_compare.py
@@ -48,10 +48,10 @@ def test_candidate_lists_shape_and_excludes_self():
 def test_lin_kernighan_valid_and_improves(seed):
     D = pairwise_distances(_cities(100, seed))
     nn = NearestNeighborTSP(
-        NearestNeighborTSPConfig(name="nn"), network_routes=D.copy()
+        config=NearestNeighborTSPConfig(name="nn"), network_routes=D.copy()
     ).solve()
     lk = LinKernighanTSP(
-        LinKernighanTSPConfig(name="lk"),
+        config=LinKernighanTSPConfig(name="lk"),
         initial_route=nn.optimal_path.copy(),
         initial_value=nn.optimal_value,
         network_routes=D.copy(),
@@ -64,7 +64,7 @@ def test_lin_kernighan_from_scratch_builds_nn_start():
     # No initial_route → setup_local_search runs NN internally.
     D = pairwise_distances(_cities(60, 7))
     lk = LinKernighanTSP(
-        LinKernighanTSPConfig(name="lk"), network_routes=D.copy()
+        config=LinKernighanTSPConfig(name="lk"), network_routes=D.copy()
     ).solve()
     assert _is_valid_tour(lk.optimal_path, 60)
 
@@ -77,7 +77,7 @@ def test_lin_kernighan_reported_length_matches_tour(seed):
     # 0 and 6 at N=40 are cases where the depot actually moves.)
     D = pairwise_distances(_cities(40, seed))
     lk = LinKernighanTSP(
-        LinKernighanTSPConfig(name="lk"), network_routes=D.copy()
+        config=LinKernighanTSPConfig(name="lk"), network_routes=D.copy()
     ).solve()
     path = lk.optimal_path
     # Depot-first, consistent with the 2-opt/3-opt solvers.

--- a/tests/test_tsp_cython.py
+++ b/tests/test_tsp_cython.py
@@ -142,7 +142,7 @@ def test_three_opt_batch_matches_singles():
 def test_solver_backend_parity(solver_cls, extra):
     D = _distances(120, seed=3)
     nn = NearestNeighborTSP(
-        NearestNeighborTSPConfig(name="nn"), network_routes=D.copy()
+        config=NearestNeighborTSPConfig(name="nn"), network_routes=D.copy()
     ).solve()
     kw = dict(
         initial_route=nn.optimal_path.copy(),
@@ -150,10 +150,10 @@ def test_solver_backend_parity(solver_cls, extra):
         network_routes=D.copy(),
     )
     r_nb = solver_cls(
-        TwoOptTSPConfig(name="x", local_search_backend="numba", **extra), **kw
+        config=TwoOptTSPConfig(name="x", local_search_backend="numba", **extra), **kw
     ).solve()
     r_cy = solver_cls(
-        TwoOptTSPConfig(name="x", local_search_backend="cython", **extra), **kw
+        config=TwoOptTSPConfig(name="x", local_search_backend="cython", **extra), **kw
     ).solve()
     assert np.array_equal(r_nb.optimal_path, r_cy.optimal_path)
     assert np.isclose(r_nb.optimal_value, r_cy.optimal_value)
@@ -257,7 +257,7 @@ def test_lk_batch_matches_singles():
 def test_lk_solver_backend_parity():
     D = _distances(150, seed=3)
     nn = NearestNeighborTSP(
-        NearestNeighborTSPConfig(name="nn"), network_routes=D.copy()
+        config=NearestNeighborTSPConfig(name="nn"), network_routes=D.copy()
     ).solve()
     kw = dict(
         initial_route=nn.optimal_path.copy(),
@@ -265,10 +265,10 @@ def test_lk_solver_backend_parity():
         network_routes=D.copy(),
     )
     r_nb = LinKernighanTSP(
-        LinKernighanTSPConfig(name="lk", local_search_backend="numba"), **kw
+        config=LinKernighanTSPConfig(name="lk", local_search_backend="numba"), **kw
     ).solve()
     r_cy = LinKernighanTSP(
-        LinKernighanTSPConfig(name="lk", local_search_backend="cython"), **kw
+        config=LinKernighanTSPConfig(name="lk", local_search_backend="cython"), **kw
     ).solve()
     assert np.array_equal(r_nb.optimal_path, r_cy.optimal_path)
     assert np.isclose(r_nb.optimal_value, r_cy.optimal_value)


### PR DESCRIPTION
## Summary
This PR refactors optimizer constructors across the codebase to enforce keyword-only arguments by adding the `*` separator after `self` in all optimizer `__init__` methods. Additionally, all constructor calls are updated to use explicit keyword arguments instead of positional arguments.

## Key Changes
- Added `*` separator to enforce keyword-only arguments in:
  - `IOptimizer` base class and all subclasses (continuous optimizers: ACO, PSO, GA, GD, StepWise; combinatorial optimizers: ACO, GA, TSP variants)
  - `MultiTypeOptimizer` and `GroupedVariableOptimizer` strategy classes
  - TSP solver classes (`TwoOptTSP`, `ThreeOptTSP`, `NearestNeighborTSP`, `ConvexHullTSP`)

- Updated all optimizer instantiations throughout the codebase to use explicit keyword arguments:
  - `optimizer_strategy.py`: Updated all optimizer instantiations in `MultiTypeOptimizer.solve()` and `GroupedVariableOptimizer.solve()`
  - Test files: Updated test instantiations in `test_map_elites.py`, `test_optimizers.py`, `test_runtime_args.py`, `test_qd_metrics.py`, `test_checkpointing.py`, `test_multi_output.py`
  - `sample.py`: Updated example code to use keyword arguments

- Updated parent class calls to use keyword arguments in all subclass `__init__` methods

## Implementation Details
- This change improves API clarity and prevents accidental positional argument misuse
- All changes are backward-incompatible for code using positional arguments, but the explicit keyword syntax is more maintainable and self-documenting
- The refactoring is comprehensive, covering both the optimizer implementations and all test/example code that instantiates them

https://claude.ai/code/session_01NYxVQz9NFpJBuFa1ZWnvrE