### PR TITLE
Fix get_clusters return values and type casting

### DIFF
--- a/src/optimizers/solution_deck.py
+++ b/src/optimizers/solution_deck.py
@@ -268,7 +268,7 @@ class SolutionDeck:
         seed = get_seed()
         k_modes_model = KModes(n_clusters=n_clusters, random_state=seed)
         cluster_labels = k_modes_model.fit_predict(self.solution_archive)
-        return cluster_labels, k_modes_model.mode_indicies_
+        return cluster_labels.astype(f64), k_modes_model.cluster_centroids_.astype(f64)
 
     # ----- Serialization helpers for checkpointing -----
     def to_dict(self) -> dict[str, Any]:


### PR DESCRIPTION
## Summary
Fixed the `get_clusters` method in `SolutionDeck` to return the correct cluster centroids instead of an invalid attribute, and ensure both return values are properly cast to float64.

## Key Changes
- Changed return value from `k_modes_model.mode_indicies_` (which doesn't exist) to `k_modes_model.cluster_centroids_` (the correct attribute containing cluster centers)
- Added `.astype(f64)` type casting to both return values to ensure they are float64 arrays
- This fixes a bug where the method would raise an AttributeError and ensures type consistency

## Implementation Details
The original code attempted to return `mode_indicies_` which is not a valid KModes model attribute. The correct attribute is `cluster_centroids_`, which contains the centroid for each cluster. Both return values are now explicitly cast to float64 to match the expected return type annotation `tuple[af64, af64]`.

https://claude.ai/code/session_01VNszUzemmUM5HJChBLXYah