### PR TITLE
Unify optimizer API surface across continuous and combinatorial solvers

### DIFF
--- a/sample.py
+++ b/sample.py
@@ -2,7 +2,7 @@ import sys
 import time
 
 from optimizers.continuous.variables import InputContinuousVariable
-from src.optimizers import AntColonyOptimizerConfig, AntColonyOptimizer
+from optimizers import AntColonyOptimizerConfig, AntColonyOptimizer
 from tests.test_optimizers import optim_ackley
 
 

--- a/samples/tsp-demo.py
+++ b/samples/tsp-demo.py
@@ -34,10 +34,10 @@ def main():
         stop_after_iterations=15,
         local_optimize=True,
     )
-    optimizer = AntColonyMTSP(config, city_locations)
+    optimizer = AntColonyMTSP(config=config, city_locations=city_locations)
     result = optimizer.solve()
-    plot_convergence(result.value_history)
-    plot_cities_and_route(city_locations, result.optimal_path)
+    plot_convergence(result.solution_history)
+    plot_cities_and_route(city_locations, result.solution_vector)
 
 
 def part1():
@@ -51,10 +51,10 @@ def part1():
         "Ant Colony",
         "Ant Colony MST",
     ]
-    plot_convergence([x.value_history for x in results], trace_names)
+    plot_convergence([x.solution_history for x in results], trace_names)
     plot_cities_and_route(
         city_locations,
-        [x.optimal_path for x in results],
+        [x.solution_vector for x in results],
         trace_names,
     )
 
@@ -66,7 +66,7 @@ def compute_tsp_bounds(cities: AF):
     # Time Nearest Neighbor
     start_time = time.time()
     nn_config = NearestNeighborTSPConfig(name="NN TSP", back_to_start=True)
-    nn_optimizer = NearestNeighborTSP(nn_config, distances)
+    nn_optimizer = NearestNeighborTSP(config=nn_config, network_routes=distances)
     nn_result = nn_optimizer.solve()
     nn_time = time.time() - start_time
 
@@ -76,9 +76,9 @@ def compute_tsp_bounds(cities: AF):
         name="2-OPT TSP", back_to_start=True, num_iterations=cities.shape[0]
     )
     topt_optimizer = TwoOptTSP(
-        topt_config,
-        initial_route=nn_result.optimal_path,
-        initial_value=nn_result.optimal_value,
+        config=topt_config,
+        initial_route=nn_result.solution_vector,
+        initial_value=nn_result.solution_score,
         network_routes=distances,
     )
     topt_result = topt_optimizer.solve()
@@ -87,7 +87,7 @@ def compute_tsp_bounds(cities: AF):
     # Time Convex Hull
     start_time = time.time()
     ch_config = ConvexHullTSPConfig(name="CH TSP", back_to_start=True)
-    ch_optimizer = ConvexHullTSP(ch_config, city_locations=cities)
+    ch_optimizer = ConvexHullTSP(config=ch_config, city_locations=cities)
     ch_result = ch_optimizer.solve()
     ch_time = time.time() - start_time
 
@@ -108,7 +108,7 @@ def compute_tsp_bounds(cities: AF):
         stop_after_iterations=n_generations * 4,  # No early stopping!
     )
     ga_optimizer = GeneticAlgorithmTSP(
-        ga_config, network_routes=distances, city_locations=cities
+        config=ga_config, network_routes=distances, city_locations=cities
     )
     ga_result = ga_optimizer.solve()
     ga_time = time.time() - start_time
@@ -125,7 +125,7 @@ def compute_tsp_bounds(cities: AF):
         stop_after_iterations=n_generations,  # No early stopping!
     )
     aco_optimizer = AntColonyTSP(
-        aco_config, network_routes=distances, city_locations=cities
+        config=aco_config, network_routes=distances, city_locations=cities
     )
     aco_result = aco_optimizer.solve()
     aco_time = time.time() - start_time
@@ -133,25 +133,25 @@ def compute_tsp_bounds(cities: AF):
     # Compute the MST
     start_time = time.time()
     aco_optimizer = AntColonyMST(
-        aco_config, network_routes=distances, city_locations=cities
+        config=aco_config, network_routes=distances, city_locations=cities
     )
     aco_mst_result = aco_optimizer.solve()
     aco_mst_time = time.time() - start_time
 
     print("\n")
     print(
-        f"TSP Upper Bound (Nearest Neighbor): {nn_result.optimal_value:.2f} (Time: {nn_time:.2f}s)"
+        f"TSP Upper Bound (Nearest Neighbor): {nn_result.solution_score:.2f} (Time: {nn_time:.2f}s)"
     )
     print(
-        f"TSP 2-OPT Solution: {topt_result.optimal_value:.2f} (Time: {topt_time:.2f}s)"
+        f"TSP 2-OPT Solution: {topt_result.solution_score:.2f} (Time: {topt_time:.2f}s)"
     )
     print(
-        f"TSP Lower Bound (Convex Hull): {ch_result.optimal_value:.2f} (Time: {ch_time:.2f}s)"
+        f"TSP Lower Bound (Convex Hull): {ch_result.solution_score:.2f} (Time: {ch_time:.2f}s)"
     )
-    print(f"TSP GA Solution: {ga_result.optimal_value:.2f} (Time: {ga_time:.2f}s)")
-    print(f"TSP ACO Solution: {aco_result.optimal_value:.2f} (Time: {aco_time:.2f}s)")
+    print(f"TSP GA Solution: {ga_result.solution_score:.2f} (Time: {ga_time:.2f}s)")
+    print(f"TSP ACO Solution: {aco_result.solution_score:.2f} (Time: {aco_time:.2f}s)")
     print(
-        f"MST ACO Solution: {aco_mst_result.optimal_value:.2f} (Time: {aco_mst_time:.2f}s)"
+        f"MST ACO Solution: {aco_mst_result.solution_score:.2f} (Time: {aco_mst_time:.2f}s)"
     )
 
     return (

--- a/src/optimizers/__init__.py
+++ b/src/optimizers/__init__.py
@@ -1,51 +1,137 @@
-from optimizers.continuous.aco import AntColonyOptimizer, AntColonyOptimizerConfig
-from optimizers.continuous.gd import (
-    GradientDescentOptimizer,
-    GradientDescentOptimizerConfig,
-)
-from optimizers.continuous.ga import (
+"""Top-level convenience surface: everything a typical user needs is importable
+directly from ``optimizers``. For scoped imports, the same names (plus the
+family-specific base classes) are also available from the submodules:
+``optimizers.continuous``, ``optimizers.combinatorial``, and ``optimizers.archive``.
+"""
+
+# Continuous (real-valued decision-vector) optimizers
+from optimizers.continuous import (
+    AntColonyOptimizer,
+    AntColonyOptimizerConfig,
     GeneticAlgorithmOptimizer,
     GeneticAlgorithmOptimizerConfig,
-)
-from optimizers.continuous.optimizer_strategy import MultiTypeOptimizer
-from optimizers.core.base import IOptimizerConfig
-from optimizers.continuous.pso import (
+    GradientDescentOptimizer,
+    GradientDescentOptimizerConfig,
     ParticleSwarmOptimizer,
     ParticleSwarmOptimizerConfig,
+    StepWiseOptimizer,
+    StepWiseOptimizerConfig,
+    MultiTypeOptimizer,
+    GroupedVariableOptimizer,
+    GroupedVariableOptimizerConfig,
 )
+
+# Combinatorial (city-permutation / TSP-family) optimizers
+from optimizers.combinatorial import (
+    AntColonyTSP,
+    AntColonyTSPConfig,
+    AntColonyMST,
+    GeneticAlgorithmTSP,
+    GeneticAlgorithmTSPConfig,
+    AntColonyMTSP,
+    AntColonyMTSPConfig,
+    TwoOptTSP,
+    TwoOptTSPConfig,
+    ThreeOptTSP,
+    LinKernighanTSP,
+    LinKernighanTSPConfig,
+    NearestNeighborTSP,
+    NearestNeighborTSPConfig,
+    ConvexHullTSP,
+    ConvexHullTSPConfig,
+    compare_tsp_heuristics,
+    format_comparison_table,
+)
+
+# Quality-diversity / MAP-Elites archive (see QD_PARETO_PLAN.md)
+from optimizers.archive import CVTArchive, QDReport, qd_score, pareto_front, hypervolume
+
+# Shared config/result/base types and the solution archive every solver uses
+from optimizers.core.base import IOptimizerConfig, OptimizerResult, BaseOptimizer
+from optimizers.solution_deck import SolutionDeck
+
+# Checkpointing
 from optimizers.checkpoint import (
     CheckpointConfig,
     save_checkpoint,
     load_checkpoint,
     run_multiple,
 )
+
+# Plotting
 from optimizers.plot import (
     plot_convergence,
+    plot_cities_and_route,
     plot_run_statistics,
+    plot_pareto_front,
+    plot_map_elites,
+    plot_benchmark_timings,
     set_show_plots,
     show_plots_enabled,
 )
+
 from optimizers.core.random import set_seed, get_seed
 
 __all__ = [
+    # Continuous
     "AntColonyOptimizer",
     "AntColonyOptimizerConfig",
-    "GradientDescentOptimizer",
-    "GradientDescentOptimizerConfig",
     "GeneticAlgorithmOptimizer",
     "GeneticAlgorithmOptimizerConfig",
-    "MultiTypeOptimizer",
+    "GradientDescentOptimizer",
+    "GradientDescentOptimizerConfig",
     "ParticleSwarmOptimizer",
     "ParticleSwarmOptimizerConfig",
+    "StepWiseOptimizer",
+    "StepWiseOptimizerConfig",
+    "MultiTypeOptimizer",
+    "GroupedVariableOptimizer",
+    "GroupedVariableOptimizerConfig",
+    # Combinatorial
+    "AntColonyTSP",
+    "AntColonyTSPConfig",
+    "AntColonyMST",
+    "GeneticAlgorithmTSP",
+    "GeneticAlgorithmTSPConfig",
+    "AntColonyMTSP",
+    "AntColonyMTSPConfig",
+    "TwoOptTSP",
+    "TwoOptTSPConfig",
+    "ThreeOptTSP",
+    "LinKernighanTSP",
+    "LinKernighanTSPConfig",
+    "NearestNeighborTSP",
+    "NearestNeighborTSPConfig",
+    "ConvexHullTSP",
+    "ConvexHullTSPConfig",
+    "compare_tsp_heuristics",
+    "format_comparison_table",
+    # Quality-diversity / MAP-Elites
+    "CVTArchive",
+    "QDReport",
+    "qd_score",
+    "pareto_front",
+    "hypervolume",
+    # Shared types
     "IOptimizerConfig",
+    "OptimizerResult",
+    "BaseOptimizer",
+    "SolutionDeck",
+    # Checkpointing
     "CheckpointConfig",
     "save_checkpoint",
     "load_checkpoint",
     "run_multiple",
+    # Plotting
     "plot_convergence",
+    "plot_cities_and_route",
     "plot_run_statistics",
+    "plot_pareto_front",
+    "plot_map_elites",
+    "plot_benchmark_timings",
     "set_show_plots",
     "show_plots_enabled",
+    # RNG
     "set_seed",
     "get_seed",
 ]

--- a/src/optimizers/combinatorial/__init__.py
+++ b/src/optimizers/combinatorial/__init__.py
@@ -1,0 +1,46 @@
+"""Combinatorial (city-permutation / TSP-family) optimizers: GA, ACO, local search."""
+
+from .base import TSPBase, check_path_distance
+from .aco import AntColonyTSP, AntColonyTSPConfig
+from .aco_mst import AntColonyMST
+from .ga import GeneticAlgorithmTSP, GeneticAlgorithmTSPConfig
+from .mtsp import AntColonyMTSP, AntColonyMTSPConfig, ClusterMethod
+from .strategy import (
+    LocalSearchBackend,
+    TwoOptTSP,
+    TwoOptTSPConfig,
+    ThreeOptTSP,
+    LinKernighanTSP,
+    LinKernighanTSPConfig,
+    NearestNeighborTSP,
+    NearestNeighborTSPConfig,
+    ConvexHullTSP,
+    ConvexHullTSPConfig,
+)
+from .compare import compare_tsp_heuristics, format_comparison_table, HeuristicResult
+
+__all__ = [
+    "TSPBase",
+    "check_path_distance",
+    "AntColonyTSP",
+    "AntColonyTSPConfig",
+    "AntColonyMST",
+    "GeneticAlgorithmTSP",
+    "GeneticAlgorithmTSPConfig",
+    "AntColonyMTSP",
+    "AntColonyMTSPConfig",
+    "ClusterMethod",
+    "LocalSearchBackend",
+    "TwoOptTSP",
+    "TwoOptTSPConfig",
+    "ThreeOptTSP",
+    "LinKernighanTSP",
+    "LinKernighanTSPConfig",
+    "NearestNeighborTSP",
+    "NearestNeighborTSPConfig",
+    "ConvexHullTSP",
+    "ConvexHullTSPConfig",
+    "compare_tsp_heuristics",
+    "format_comparison_table",
+    "HeuristicResult",
+]

--- a/src/optimizers/combinatorial/aco.py
+++ b/src/optimizers/combinatorial/aco.py
@@ -4,21 +4,21 @@ from typing import Optional
 import numpy as np
 from joblib import delayed
 
-from .base import CombinatoricsResult, TSPBase, _check_stop_early
+from .base import TSPBase, _check_stop_early
 from .strategy import TwoOptTSPConfig, TwoOptTSP
-from ..core.base import IOptimizerConfig, setup_for_generations
+from ..core.base import IOptimizerConfig, OptimizerResult, setup_for_generations
 from ..core.types import AI, AF, F, ab8, i32, i16, ai64
 
 
 @dataclass
 class AntColonyTSPConfig(IOptimizerConfig):
-    rho: float = 0.2  # 0.451  # 0.5
+    rho: float = 0.2
     """Pheromone decay parameter"""
-    alpha: float = 0.8  # 1.88  # 1.0
+    alpha: float = 0.8
     """Pheromone deposit parameter"""
-    beta: float = 2  # 1.88  # 1.0
+    beta: float = 2
     """Pheromone evaporation parameter"""
-    q: float = 1  # 2.17  # 1.0
+    q: float = 1
     """Weighting parameter for selecting better ranked solutions"""
     back_to_start: bool = True
     """Whether to return to the start node"""
@@ -31,6 +31,8 @@ class AntColonyTSPConfig(IOptimizerConfig):
 
 
 class AntColonyTSP(TSPBase):
+    config: AntColonyTSPConfig
+
     def __init__(
         self,
         *,
@@ -38,10 +40,11 @@ class AntColonyTSP(TSPBase):
         network_routes: Optional[AF] = None,
         city_locations: Optional[AF] = None,
     ):
-        super().__init__(network_routes, city_locations)
-        self.config = config
+        super().__init__(
+            config=config, network_routes=network_routes, city_locations=city_locations
+        )
 
-    def solve(self) -> CombinatoricsResult:
+    def solve(self, *, preserve_percent: float = 0.0) -> OptimizerResult:
         self.network_routes[self.network_routes == 0] = -1
         # TODO - Should we not cache this for memory efficiency?
         eta = 1.0 / self.network_routes
@@ -135,20 +138,22 @@ class AntColonyTSP(TSPBase):
                 city_locations=self.city_locations,
             )
             result = two_opt_optimize.solve()
-            tour_lengths.append(result.optimal_value)
+            tour_lengths.append(result.solution_score)
 
-            return CombinatoricsResult(
-                optimal_path=result.optimal_path,
-                optimal_value=result.optimal_value,
-                value_history=np.array(tour_lengths),
+            return OptimizerResult(
+                solution_vector=result.solution_vector,
+                solution_score=result.solution_score,
+                solution_history=np.array(tour_lengths),
                 stop_reason="max_iterations" if stop_reason == "none" else stop_reason,
+                generations_completed=generations_completed + 1,
             )
         else:
-            return CombinatoricsResult(
-                optimal_path=optimal_city_order,
-                optimal_value=optimal_tour_length,
-                value_history=np.array(tour_lengths),
+            return OptimizerResult(
+                solution_vector=optimal_city_order,
+                solution_score=optimal_tour_length,
+                solution_history=np.array(tour_lengths),
                 stop_reason="max_iterations" if stop_reason == "none" else stop_reason,
+                generations_completed=generations_completed + 1,
             )
 
 

--- a/src/optimizers/combinatorial/aco_mst.py
+++ b/src/optimizers/combinatorial/aco_mst.py
@@ -3,8 +3,8 @@ from typing import Optional
 import numpy as np
 from joblib import delayed
 
-from .base import CombinatoricsResult, TSPBase, _check_stop_early
-from ..core.base import setup_for_generations
+from .base import TSPBase, _check_stop_early
+from ..core.base import OptimizerResult, setup_for_generations
 from ..core.types import AI, AF, F, ab8, i32, i16, ai64
 from .aco import AntColonyTSPConfig
 
@@ -12,16 +12,22 @@ from .aco import AntColonyTSPConfig
 
 
 class AntColonyMST(TSPBase):
+    config: AntColonyTSPConfig
+
     def __init__(
         self,
+        *,
         config: AntColonyTSPConfig,
         network_routes: Optional[AF] = None,
         city_locations: Optional[AF] = None,
     ):
-        super().__init__(network_routes, city_locations)
-        self.config = config
+        super().__init__(
+            config=config, network_routes=network_routes, city_locations=city_locations
+        )
 
-    def solve(self, start_idx: int = 0) -> CombinatoricsResult:
+    def solve(
+        self, *, preserve_percent: float = 0.0, start_idx: int = 0
+    ) -> OptimizerResult:
         self.network_routes[self.network_routes == 0] = -1
         # TODO - Should we not cache this for memory efficiency?
         eta = 1.0 / self.network_routes
@@ -97,11 +103,12 @@ class AntColonyMST(TSPBase):
                 if stop_reason != "none":
                     break
 
-            return CombinatoricsResult(
-                optimal_path=optimal_city_order,
-                optimal_value=optimal_tour_length,
-                value_history=np.array(tour_lengths),
+            return OptimizerResult(
+                solution_vector=optimal_city_order,
+                solution_score=optimal_tour_length,
+                solution_history=np.array(tour_lengths),
                 stop_reason="max_iterations" if stop_reason == "none" else stop_reason,
+                generations_completed=generations_completed + 1,
             )
 
 

--- a/src/optimizers/combinatorial/base.py
+++ b/src/optimizers/combinatorial/base.py
@@ -1,19 +1,8 @@
-from abc import ABC, abstractmethod
-
 import numpy as np
 from sklearn.metrics import pairwise_distances
 
 from ..core.types import AF, AI, F
-from ..core.base import StopReason, IOptimizerConfig
-from dataclasses import dataclass
-
-
-@dataclass
-class CombinatoricsResult:
-    optimal_path: AI | list[AI]
-    optimal_value: F
-    value_history: AF | list[AF]
-    stop_reason: StopReason
+from ..core.base import BaseOptimizer, StopReason, IOptimizerConfig
 
 
 def check_path_distance(
@@ -45,7 +34,7 @@ def _check_stop_early(config: IOptimizerConfig, soln_history: list[F]) -> StopRe
     return "none"
 
 
-class TSPBase(ABC):
+class TSPBase(BaseOptimizer):
     # ``network_routes`` is always populated by ``set_network_routes`` during
     # __init__ (the None branch asserts city_locations is present), so it is a
     # non-Optional distance matrix for the lifetime of the solver.
@@ -54,9 +43,12 @@ class TSPBase(ABC):
 
     def __init__(
         self,
+        *,
+        config: IOptimizerConfig,
         network_routes: AF | None = None,
         city_locations: AF | None = None,
     ):
+        self.config = config
         self.city_locations = None
         self.set_network_routes(network_routes, city_locations)
 
@@ -74,9 +66,3 @@ class TSPBase(ABC):
             self.network_routes = pairwise_distances(city_locations)
         else:
             self.network_routes = network_routes.copy()
-
-    @abstractmethod
-    def solve(self) -> CombinatoricsResult:
-        raise NotImplementedError(
-            "This method should be implemented in the base classes"
-        )

--- a/src/optimizers/combinatorial/compare.py
+++ b/src/optimizers/combinatorial/compare.py
@@ -16,7 +16,7 @@ import numpy as np
 from sklearn.metrics import pairwise_distances
 
 from ..core.types import AF, AI
-from .base import CombinatoricsResult
+from ..core.base import OptimizerResult
 from .strategy import (
     NearestNeighborTSP,
     NearestNeighborTSPConfig,
@@ -56,8 +56,8 @@ def _warmup(distances: AF, backend: LocalSearchBackend) -> None:
     seed = NearestNeighborTSP(
         config=NearestNeighborTSPConfig(name="w"), network_routes=cast(AF, d.copy())
     ).solve()
-    seed_route = cast(AI, np.ascontiguousarray(seed.optimal_path))
-    seed_value = seed.optimal_value
+    seed_route = cast(AI, np.ascontiguousarray(seed.solution_vector))
+    seed_value = seed.solution_score
     TwoOptTSP(
         config=TwoOptTSPConfig(name="w", local_search_backend=backend),
         network_routes=cast(AF, d.copy()),
@@ -100,7 +100,7 @@ def compare_tsp_heuristics(
     if warmup:
         _warmup(distances, backend)
 
-    records: list[tuple[str, CombinatoricsResult, float]] = []
+    records: list[tuple[str, OptimizerResult, float]] = []
 
     t0 = time.perf_counter()
     nn = NearestNeighborTSP(
@@ -109,9 +109,9 @@ def compare_tsp_heuristics(
     ).solve()
     records.append(("Nearest Neighbor", nn, time.perf_counter() - t0))
 
-    seed_route, seed_val = nn.optimal_path, nn.optimal_value
+    seed_route, seed_val = nn.solution_vector, nn.solution_score
 
-    def _timed(cls: Any, config: Any) -> tuple[CombinatoricsResult, float]:
+    def _timed(cls: Any, config: Any) -> tuple[OptimizerResult, float]:
         t = time.perf_counter()
         result = cls(
             config=config,
@@ -152,17 +152,17 @@ def compare_tsp_heuristics(
     )
     records.append(("Lin-Kernighan", r, dt))
 
-    best = min(float(res.optimal_value) for _, res, _ in records)
+    best = min(float(res.solution_score) for _, res, _ in records)
     return [
         HeuristicResult(
             name=name,
-            tour_length=float(res.optimal_value),
+            tour_length=float(res.solution_score),
             runtime_s=dt,
             gap_pct=(
-                100.0 * (float(res.optimal_value) - best) / best if best > 0 else 0.0
+                100.0 * (float(res.solution_score) - best) / best if best > 0 else 0.0
             ),
             # These heuristics all return a single tour (never a list of tours).
-            optimal_path=cast(AI, res.optimal_path),
+            optimal_path=cast(AI, res.solution_vector),
         )
         for name, res, dt in records
     ]

--- a/src/optimizers/combinatorial/ga.py
+++ b/src/optimizers/combinatorial/ga.py
@@ -4,18 +4,18 @@ from typing import Optional
 import numpy as np
 from joblib import delayed
 
-from .base import TSPBase, CombinatoricsResult, _check_stop_early, check_path_distance
+from .base import TSPBase, _check_stop_early, check_path_distance
 from .strategy import TwoOptTSPConfig, TwoOptTSP
 from ..core import IOptimizerConfig
-from ..core.base import setup_for_generations
+from ..core.base import OptimizerResult, setup_for_generations
 from ..core.types import AF, AI, F
 
 
 @dataclass
 class GeneticAlgorithmTSPConfig(IOptimizerConfig):
-    mutation_rate: float = 0.105  # 0.1
+    mutation_rate: float = 0.105
     """Probability of mutation"""
-    crossover_rate: float = 0.190  # 0.8
+    crossover_rate: float = 0.190
     """Probability of crossover"""
     back_to_start: bool = True
     """Whether to return to the start node"""
@@ -28,6 +28,8 @@ class GeneticAlgorithmTSPConfig(IOptimizerConfig):
 
 
 class GeneticAlgorithmTSP(TSPBase):
+    config: GeneticAlgorithmTSPConfig
+
     def __init__(
         self,
         *,
@@ -35,10 +37,11 @@ class GeneticAlgorithmTSP(TSPBase):
         network_routes: Optional[AF] = None,
         city_locations: Optional[AF] = None,
     ):
-        super().__init__(network_routes, city_locations)
-        self.config = config
+        super().__init__(
+            config=config, network_routes=network_routes, city_locations=city_locations
+        )
 
-    def solve(self) -> CombinatoricsResult:
+    def solve(self, *, preserve_percent: float = 0.0) -> OptimizerResult:
         self.network_routes[self.network_routes == 0] = -1
         # Allocate the genome candidates
         genome = np.zeros(
@@ -133,20 +136,22 @@ class GeneticAlgorithmTSP(TSPBase):
                 city_locations=self.city_locations,
             )
             result = two_opt_optimize.solve()
-            tour_lengths.append(result.optimal_value)
+            tour_lengths.append(result.solution_score)
 
-            return CombinatoricsResult(
-                optimal_path=result.optimal_path,
-                optimal_value=result.optimal_value,
-                value_history=np.array(tour_lengths),
+            return OptimizerResult(
+                solution_vector=result.solution_vector,
+                solution_score=result.solution_score,
+                solution_history=np.array(tour_lengths),
                 stop_reason="max_iterations" if stop_reason == "none" else stop_reason,
+                generations_completed=generations_completed + 1,
             )
         else:
-            return CombinatoricsResult(
-                optimal_path=genome[0, :],
-                optimal_value=genome_value[0],
-                value_history=np.array(tour_lengths),
+            return OptimizerResult(
+                solution_vector=genome[0, :],
+                solution_score=genome_value[0],
+                solution_history=np.array(tour_lengths),
                 stop_reason="max_iterations" if stop_reason == "none" else stop_reason,
+                generations_completed=generations_completed + 1,
             )
 
 

--- a/src/optimizers/combinatorial/mtsp.py
+++ b/src/optimizers/combinatorial/mtsp.py
@@ -1,17 +1,19 @@
 from dataclasses import dataclass
-from typing import Literal, NoReturn
+from typing import Literal
 
 import numpy as np
 from sklearn.cluster import KMeans, SpectralClustering
 
-from .base import CombinatoricsResult
+from .base import TSPBase
 from .aco import AntColonyTSPConfig, AntColonyTSP
-from ..continuous.aco import AntColonyOptimizer, AntColonyOptimizerConfig
-from ..continuous.variables import InputDiscreteVariable
-from ..core.base import create_from_dict, literal_options
+from ..core.base import OptimizerResult, create_from_dict, literal_options
 from ..core.types import AF
 
-ClusterMethod = Literal["kmeans", "spectral", "FCM", "TSP"]
+# NOTE: "FCM" is accepted but always raises NotImplementedError (see
+# do_clustering) -- the fuzzy c-means dependency was unreliable enough that the
+# implementation was pulled, but the option is left here (rather than removed)
+# as a documented placeholder for whoever restores it.
+ClusterMethod = Literal["kmeans", "spectral", "FCM"]
 
 
 @dataclass
@@ -21,59 +23,16 @@ class AntColonyMTSPConfig(AntColonyTSPConfig):
     clustering_method: ClusterMethod = "kmeans"
 
 
-class AntColonyMTSP:
-    def __init__(self, config: AntColonyMTSPConfig, city_locations: AF):
-        self.config = config
-        self.city_locations: AF = city_locations.copy()
+class AntColonyMTSP(TSPBase):
+    """Multiple-TSP: cluster cities, then solve an independent ACO tour per cluster."""
 
-    def solve(self) -> CombinatoricsResult:
+    config: AntColonyMTSPConfig
+
+    def __init__(self, *, config: AntColonyMTSPConfig, city_locations: AF):
+        super().__init__(config=config, city_locations=city_locations)
+
+    def solve(self, *, preserve_percent: float = 0.0) -> OptimizerResult:
         # TODO - Handle the number of processors based upon parallel clusters?
-        if self.config.clustering_method == "TSP":
-            return self.solve_tsp()
-        else:
-            return self.solve_clustering()
-
-    def solve_tsp(self) -> NoReturn:
-        # Create n_cities DiscreteVariable with the options being each cluster
-        cluster_ids = np.arange(self.config.n_clusters)
-        variables = [
-            InputDiscreteVariable(f"cluster_{i}", cluster_ids)
-            for i in range(self.city_locations.shape[0])
-        ]
-        solver_config = create_from_dict(self.config.__dict__, AntColonyOptimizerConfig)
-        tsp_config = create_from_dict(self.config.__dict__, AntColonyTSPConfig)
-        # Because this is a multi-level optimization, don't parallelize here.
-        # (was ``joblib_num_procs``, a no-op typo — the config field is ``n_jobs``.)
-        solver_config.n_jobs = 1
-
-        def goal_fcn(x: AF) -> float:
-            x = np.int32(x)
-            # Iterate over the number of clusters, and do each cluster's TSP optimization separately.
-            total_value = 0.0
-            for cluster_id in range(self.config.n_clusters):
-                cluster_cities = self.city_locations[x == cluster_id, :]
-                if len(cluster_cities) == 0:
-                    continue
-                tsp_config.name = f"{tsp_config.name}-{cluster_id + 1}"
-                tsp_solve = AntColonyTSP(
-                    config=tsp_config,
-                    city_locations=cluster_cities,
-                )
-                tsp_result = tsp_solve.solve()
-                total_value += tsp_result.optimal_value
-            return total_value
-
-        solver = AntColonyOptimizer(
-            config=solver_config,
-            variables=variables,
-            fcn=goal_fcn,
-        )
-        solver.solve()
-
-        raise ValueError("TSP clustering is not yet supported")
-
-    def solve_clustering(self) -> CombinatoricsResult:
-        # Perform k-means clustering
         clusters = self.do_clustering()
 
         results = []
@@ -86,19 +45,19 @@ class AntColonyMTSP:
             )
             cluster_result = tsp_solve.solve()
             # Map cluster indices back to original indices
-            cluster_result.optimal_path = np.array(
-                [cluster[i] for i in cluster_result.optimal_path]
+            cluster_result.solution_vector = np.array(
+                [cluster[i] for i in cluster_result.solution_vector]
             )
 
             results.append(cluster_result)
 
-        optimal_paths = [result.optimal_path for result in results]
+        optimal_paths = [result.solution_vector for result in results]
 
-        return CombinatoricsResult(
-            value_history=[result.value_history for result in results],
-            optimal_value=np.sum([result.optimal_value for result in results]),
+        return OptimizerResult(
+            solution_history=[result.solution_history for result in results],
+            solution_score=np.sum([result.solution_score for result in results]),
             stop_reason="max_iterations",
-            optimal_path=optimal_paths,
+            solution_vector=optimal_paths,
         )
 
     def do_clustering(self) -> list[list[int]]:

--- a/src/optimizers/combinatorial/strategy.py
+++ b/src/optimizers/combinatorial/strategy.py
@@ -5,7 +5,8 @@ import numpy as np
 from numba import njit
 
 from ..core import IOptimizerConfig
-from .base import TSPBase, CombinatoricsResult, check_path_distance
+from ..core.base import OptimizerResult
+from .base import TSPBase, check_path_distance
 from ..core.types import AI, F, AF
 
 # Optional compiled backend (2-opt / 3-opt). Built via `setup.py build_ext`
@@ -382,6 +383,8 @@ def _lk_kernel(distances: AF, tour: AI, cand: AI, max_passes: int) -> int:  # no
 
 
 class TwoOptTSP(TSPBase):
+    config: TwoOptTSPConfig
+
     def __init__(
         self,
         *,
@@ -391,12 +394,13 @@ class TwoOptTSP(TSPBase):
         initial_route: Optional[AI] = None,
         initial_value: Optional[F] = None,
     ):
-        super().__init__(network_routes, city_locations)
-        self.config = config
+        super().__init__(
+            config=config, network_routes=network_routes, city_locations=city_locations
+        )
         self.initial_value = initial_value
         self.initial_route = initial_route
 
-    def solve(self) -> CombinatoricsResult:
+    def solve(self, *, preserve_percent: float = 0.0) -> OptimizerResult:
         N, new_route = self.setup_local_search()
         # Compiled 2-opt (report item #13); logic identical across backends.
         new_route = np.ascontiguousarray(new_route)
@@ -435,10 +439,10 @@ class TwoOptTSP(TSPBase):
         out = np.append(tour, tour[0]) if self.config.back_to_start else tour
         history = [value]
 
-        return CombinatoricsResult(
-            optimal_path=np.array(out),
-            optimal_value=value,
-            value_history=np.array(history),
+        return OptimizerResult(
+            solution_vector=np.array(out),
+            solution_score=value,
+            solution_history=np.array(history),
             stop_reason="no_improvement" if no_moves else "max_iterations",
         )
 
@@ -454,8 +458,8 @@ class TwoOptTSP(TSPBase):
                 city_locations=self.city_locations,
             )
             solution = nn_solver.solve()
-            self.initial_route = solution.optimal_path
-            self.initial_value = solution.optimal_value
+            self.initial_route = solution.solution_vector
+            self.initial_value = solution.solution_score
         assert self.initial_route is not None
         new_route = self.initial_route.copy()
         N = self.network_routes.shape[0]
@@ -480,7 +484,7 @@ class ThreeOptTSP(TwoOptTSP):
             city_locations=city_locations,
         )
 
-    def solve(self) -> CombinatoricsResult:
+    def solve(self, *, preserve_percent: float = 0.0) -> OptimizerResult:
         N, new_route = self.setup_local_search()
         # Compiled 3-opt (report item #13); num_iterations=-1 is a no-op pass.
         new_route = np.ascontiguousarray(new_route)
@@ -515,10 +519,10 @@ class ThreeOptTSP(TwoOptTSP):
         out = np.append(tour, tour[0]) if self.config.back_to_start else tour
         history = [value]
 
-        return CombinatoricsResult(
-            optimal_path=np.array(out),
-            optimal_value=value,
-            value_history=np.array(history),
+        return OptimizerResult(
+            solution_vector=np.array(out),
+            solution_score=value,
+            solution_history=np.array(history),
             stop_reason="no_improvement" if no_moves else "max_iterations",
         )
 
@@ -543,7 +547,7 @@ class LinKernighanTSP(TwoOptTSP):
 
     config: LinKernighanTSPConfig
 
-    def solve(self) -> CombinatoricsResult:
+    def solve(self, *, preserve_percent: float = 0.0) -> OptimizerResult:
         _, new_route = self.setup_local_search()
         route = np.ascontiguousarray(new_route)
         N = self.network_routes.shape[0]
@@ -581,10 +585,10 @@ class LinKernighanTSP(TwoOptTSP):
         if self.config.back_to_start:
             out = np.append(tour, tour[0])
         value = check_path_distance(self.network_routes, out, self.config.back_to_start)
-        return CombinatoricsResult(
-            optimal_path=np.array(out),
-            optimal_value=value,
-            value_history=np.array([value]),
+        return OptimizerResult(
+            solution_vector=np.array(out),
+            solution_score=value,
+            solution_history=np.array([value]),
             stop_reason="no_improvement" if n_moves == 0 else "max_iterations",
         )
 
@@ -596,6 +600,8 @@ class NearestNeighborTSPConfig(IOptimizerConfig):
 
 
 class NearestNeighborTSP(TSPBase):
+    config: NearestNeighborTSPConfig
+
     def __init__(
         self,
         *,
@@ -603,10 +609,11 @@ class NearestNeighborTSP(TSPBase):
         network_routes: Optional[AF] = None,
         city_locations: Optional[AF] = None,
     ):
-        super().__init__(network_routes, city_locations)
-        self.config = config
+        super().__init__(
+            config=config, network_routes=network_routes, city_locations=city_locations
+        )
 
-    def solve(self) -> CombinatoricsResult:
+    def solve(self, *, preserve_percent: float = 0.0) -> OptimizerResult:
         # Start at the first node, pick the nearest neighbor. Uses a boolean
         # visited mask + argmin over the current row (report item #13) instead of
         # a Python ``set`` membership scan; argmin's first-min tie-break matches
@@ -640,10 +647,10 @@ class NearestNeighborTSP(TSPBase):
             total_distance += self.network_routes[current_node][0]
             route.append(0)
 
-        return CombinatoricsResult(
-            optimal_path=np.array(route),
-            optimal_value=total_distance,
-            value_history=np.array([total_distance]),
+        return OptimizerResult(
+            solution_vector=np.array(route),
+            solution_score=total_distance,
+            solution_history=np.array([total_distance]),
             stop_reason="none",
         )
 
@@ -655,6 +662,8 @@ class ConvexHullTSPConfig(IOptimizerConfig):
 
 
 class ConvexHullTSP(TSPBase):
+    config: ConvexHullTSPConfig
+
     def __init__(
         self,
         *,
@@ -662,10 +671,11 @@ class ConvexHullTSP(TSPBase):
         network_routes: Optional[AF] = None,
         city_locations: Optional[AF] = None,
     ):
-        super().__init__(network_routes, city_locations)
-        self.config = config
+        super().__init__(
+            config=config, network_routes=network_routes, city_locations=city_locations
+        )
 
-    def solve(self) -> CombinatoricsResult:
+    def solve(self, *, preserve_percent: float = 0.0) -> OptimizerResult:
         # Use the windmill method starting at point-0.
         # NOTE - This will give us the convex hull PLUS the sequence required to get there.
         current_node = 0
@@ -711,9 +721,9 @@ class ConvexHullTSP(TSPBase):
                 break
             visited.add(current_node)
 
-        return CombinatoricsResult(
-            optimal_path=np.array(tour),
-            optimal_value=total_distance,
-            value_history=np.array([total_distance]),
+        return OptimizerResult(
+            solution_vector=np.array(tour),
+            solution_score=total_distance,
+            solution_history=np.array([total_distance]),
             stop_reason="none",
         )

--- a/src/optimizers/continuous/__init__.py
+++ b/src/optimizers/continuous/__init__.py
@@ -1,0 +1,32 @@
+"""Continuous (real-valued decision-vector) optimizers: GA, PSO, ACO, GD, and strategies."""
+
+from .base import IOptimizer
+from .aco import AntColonyOptimizer, AntColonyOptimizerConfig
+from .ga import GeneticAlgorithmOptimizer, GeneticAlgorithmOptimizerConfig
+from .gd import GradientDescentOptimizer, GradientDescentOptimizerConfig
+from .pso import ParticleSwarmOptimizer, ParticleSwarmOptimizerConfig
+from .step import StepWiseOptimizer, StepWiseOptimizerConfig
+from .optimizer_strategy import (
+    MultiTypeOptimizer,
+    GroupedVariableOptimizer,
+    GroupedVariableOptimizerConfig,
+    InputVariableGroup,
+)
+
+__all__ = [
+    "IOptimizer",
+    "AntColonyOptimizer",
+    "AntColonyOptimizerConfig",
+    "GeneticAlgorithmOptimizer",
+    "GeneticAlgorithmOptimizerConfig",
+    "GradientDescentOptimizer",
+    "GradientDescentOptimizerConfig",
+    "ParticleSwarmOptimizer",
+    "ParticleSwarmOptimizerConfig",
+    "StepWiseOptimizer",
+    "StepWiseOptimizerConfig",
+    "MultiTypeOptimizer",
+    "GroupedVariableOptimizer",
+    "GroupedVariableOptimizerConfig",
+    "InputVariableGroup",
+]

--- a/src/optimizers/continuous/aco.py
+++ b/src/optimizers/continuous/aco.py
@@ -15,14 +15,12 @@ from ..core.base import (
 from ..continuous.base import check_stop_early, cdf, sync_worker_meta
 from ..core.parallel import GenerationRunner
 from ..core.types import af64
-from ..solution_deck import (
-    SolutionDeck,
-)
+from ..solution_deck import SolutionDeck
 from ..core.random import rng as global_rng
 from ..archive.variation import iso_line_offspring
 
 from .base import IOptimizer
-from ..core.variables import InputVariables
+from ..core import InputVariables
 
 
 @dataclass
@@ -138,7 +136,7 @@ class AntColonyOptimizer(IOptimizer):
             **{**config.__dict__}
         )
 
-    def solve(self, preserve_percent: float = 0.0) -> OptimizerResult:
+    def solve(self, *, preserve_percent: float = 0.0) -> OptimizerResult:
         (
             best_soln_history,
             generation_pbar,

--- a/src/optimizers/continuous/base.py
+++ b/src/optimizers/continuous/base.py
@@ -1,4 +1,3 @@
-import abc
 import tqdm
 import joblib
 import numpy as np
@@ -7,10 +6,10 @@ import uuid
 import inspect
 from typing import Optional, Any, Callable
 
-from ..core import InputVariables
+from ..core import InputVariables, WrappedGoalFcn
 from ..core.base import (
+    BaseOptimizer,
     IOptimizerConfig,
-    OptimizerResult,
     OptimizerRun,
     StopReason,
     ensure_literal_choice,
@@ -24,10 +23,7 @@ from ..core.base import (
 )
 from ..core.types import AF, F
 from ..core.random import get_seed
-from ..solution_deck import (
-    SolutionDeck,
-    WrappedGoalFcn,
-)
+from ..solution_deck import SolutionDeck
 from ..archive.cvt import CVTArchive
 from ..archive.descriptor import RandomProjectionDescriptor
 from ..archive.metrics import QDReport, qd_score, pareto_front, hypervolume
@@ -132,7 +128,7 @@ class _ArgProvider:
         self.meta["eval_count"] = self.eval_base
 
 
-class IOptimizer(abc.ABC):
+class IOptimizer(BaseOptimizer):
     """Base class for all optimizer implementations"""
 
     def __init__(
@@ -208,7 +204,7 @@ class IOptimizer(abc.ABC):
                     result = _f(x)
                 # Multi-output goal fns return (fitness, outputs); solvers only
                 # ever need the scalar fitness.
-                return result[0] if self._returns_outputs else result  # type: ignore[call-overload]
+                return result[0] if self._returns_outputs else result
 
             return __wrapped
 
@@ -336,13 +332,6 @@ class IOptimizer(abc.ABC):
 
     def _set_generation(self, generation: int) -> None:
         self._arg_provider.meta["generation"] = generation
-
-    @abc.abstractmethod
-    def solve(self, preserve_percent: float = 0.0) -> OptimizerResult:
-        """
-        Solve the given problem.
-        """
-        raise NotImplementedError("This method should be overridden by subclasses.")
 
     def initialize(
         self, preserve_percent: float

--- a/src/optimizers/continuous/base.py
+++ b/src/optimizers/continuous/base.py
@@ -190,7 +190,7 @@ class IOptimizer(BaseOptimizer):
 
             def __wrapped(
                 x: AF,
-                _f: Callable[..., F] = func,
+                _f: Callable[..., Any] = func,
                 _ap: "_ArgProvider" = self._arg_provider,
             ) -> F:
                 # Only pay the runtime-metadata bookkeeping (a time.time() call
@@ -203,8 +203,14 @@ class IOptimizer(BaseOptimizer):
                 else:
                     result = _f(x)
                 # Multi-output goal fns return (fitness, outputs); solvers only
-                # ever need the scalar fitness.
-                return result[0] if self._returns_outputs else result
+                # ever need the scalar fitness. Unpacking (rather than indexing
+                # a value mypy sees as the scalar type F) keeps this checkable
+                # across numpy versions -- some numpy typeshed releases don't
+                # offer a generic.__getitem__(int) overload.
+                if self._returns_outputs:
+                    fitness, _outputs = result
+                    return fitness
+                return result
 
             return __wrapped
 

--- a/src/optimizers/continuous/ga.py
+++ b/src/optimizers/continuous/ga.py
@@ -18,15 +18,13 @@ from .base import (
     check_stop_early,
     sync_worker_meta,
 )
-from ..core.variables import InputVariables
+from ..core import InputVariables
 from ..core.random import rng as global_rng
 from ..core.parallel import GenerationRunner
 from ..archive.variation import iso_line_offspring
 from .base import IOptimizer
 
-from ..solution_deck import (
-    SolutionDeck,
-)
+from ..solution_deck import SolutionDeck
 
 
 @dataclass
@@ -218,7 +216,7 @@ class GeneticAlgorithmOptimizer(IOptimizer):
             **{**config.__dict__}
         )
 
-    def solve(self, preserve_percent: float = 0.0) -> OptimizerResult:
+    def solve(self, *, preserve_percent: float = 0.0) -> OptimizerResult:
         (
             best_soln_history,
             generation_pbar,

--- a/src/optimizers/continuous/gd.py
+++ b/src/optimizers/continuous/gd.py
@@ -12,10 +12,7 @@ from ..core.base import (
     InputArguments,
 )
 from ..core.types import AF
-from ..solution_deck import (
-    WrappedGoalFcn,
-    InputVariables,
-)
+from ..core import WrappedGoalFcn, InputVariables
 from ..core.tqdm_joblib import tqdm_joblib
 from .base import IOptimizer
 from .variables import InputContinuousVariable, InputDiscreteVariable
@@ -135,7 +132,7 @@ class GradientDescentOptimizer(IOptimizer):
         if nested:
             self.config.n_jobs = 1
 
-    def solve(self, preserve_percent: float = 0.0) -> OptimizerResult:
+    def solve(self, *, preserve_percent: float = 0.0) -> OptimizerResult:
         """Solve the optimization problem using gradient descent.
 
         Args:

--- a/src/optimizers/continuous/local.py
+++ b/src/optimizers/continuous/local.py
@@ -1,9 +1,9 @@
 from .gd import solve_gd_for_1var, solve_gd_from_x0
 from ..core.base import LocalOptimType, ensure_literal_choice
-from ..solution_deck import WrappedGoalFcn
+from ..core import WrappedGoalFcn
 from .variables import InputVariable, InputDiscreteVariable
 from ..core.types import AF, F
-from typing import get_args
+from typing import cast, get_args
 
 
 def apply_local_optimization(
@@ -64,7 +64,7 @@ def full_grad_optim(
     # Configure a continuous only gradient optimizer around this (ACO handles the discrete variable searching already)
     # Don't fire this off on another process, to prevent overloading the OS.
     result, _ = solve_gd_from_x0(new_solution, variables, fcn)
-    new_solution = result.solution_vector
+    new_solution = cast(AF, result.solution_vector)
     # Re-evaluate at the returned vector so the stored score is exactly the
     # objective at the stored solution. scipy's res.fun can differ from
     # fcn(res.x) by ~1e-10 near an optimum (line-search artifact), which would
@@ -81,7 +81,7 @@ def single_var_grad_optim(
         if isinstance(variable, InputDiscreteVariable):
             continue
         result = solve_gd_for_1var(new_solution, variables, var_idx, fcn)
-        new_solution = result.solution_vector
+        new_solution = cast(AF, result.solution_vector)
     # Re-evaluate once at the final vector so the stored (vector, value) pair is
     # exactly consistent (see full_grad_optim for the rationale).
     new_value = fcn(new_solution)

--- a/src/optimizers/continuous/optimizer_strategy.py
+++ b/src/optimizers/continuous/optimizer_strategy.py
@@ -16,7 +16,7 @@ from ..core.base import (
     InputArguments,
 )
 from .base import IOptimizer
-from ..solution_deck import InputVariables
+from ..core import InputVariables
 from .aco import AntColonyOptimizer, AntColonyOptimizerConfig
 from .pso import ParticleSwarmOptimizer, ParticleSwarmOptimizerConfig
 from .ga import GeneticAlgorithmOptimizer, GeneticAlgorithmOptimizerConfig
@@ -91,13 +91,21 @@ class MultiTypeOptimizer(IOptimizer):
         self.fcn = fcn
         self.optimizer_choice_history: list[OptimizationType] = []
 
-    def solve(
+    def solve(self, *, preserve_percent: float = 0.0) -> OptimizerResult:
+        return self._solve_with_restarts(preserve_percent=preserve_percent)
+
+    def _solve_with_restarts(
         self,
+        *,
         preserve_percent: float = 0.0,
         restart_count: int = 0,
         max_restart: int = 5,
         generations_completed: int = 0,
     ) -> OptimizerResult:
+        # ``preserve_percent`` is accepted for parity with ``solve()``'s public
+        # signature but not threaded through here: each restart's delegate
+        # optimizer picks its own preserve_percent below (0.0 on the first
+        # attempt, 0.1 on restarts, to warm-start from the previous archive).
         selected_type = (
             self.optimizer_selector.select(self.optimizer_choice_history[-1])
             if restart_count > 0
@@ -160,7 +168,7 @@ class MultiTypeOptimizer(IOptimizer):
                 f"Optimizer {selected_type} stopped early, selecting a new optimizer."
             )
 
-            return result + self.solve(
+            return result + self._solve_with_restarts(
                 restart_count=restart_count + 1,
                 generations_completed=generations_completed
                 + result.generations_completed,
@@ -210,7 +218,7 @@ class GroupedVariableOptimizer(IOptimizer):
                 x_i += 1
         return y
 
-    def solve(self, preserve_percent: float = 0.0) -> OptimizerResult:
+    def solve(self, *, preserve_percent: float = 0.0) -> OptimizerResult:
         # TODO - Progress bar?
         # TODO - Pass in previous best solution deck
         # TODO - Support for check-pointing!

--- a/src/optimizers/continuous/pso.py
+++ b/src/optimizers/continuous/pso.py
@@ -12,10 +12,8 @@ from ..core.base import (
     BatchGoalFcn,
 )
 from ..core.types import AF
-from ..solution_deck import (
-    InputVariables,
-    SolutionDeck,
-)
+from ..core import InputVariables
+from ..solution_deck import SolutionDeck
 from .base import (
     IOptimizer,
     check_stop_early,
@@ -223,7 +221,7 @@ class ParticleSwarmOptimizer(IOptimizer):
             **{**config.__dict__}
         )
 
-    def solve(self, preserve_percent: float = 0.0) -> OptimizerResult:
+    def solve(self, *, preserve_percent: float = 0.0) -> OptimizerResult:
         (
             best_soln_history,
             generation_pbar,

--- a/src/optimizers/continuous/step.py
+++ b/src/optimizers/continuous/step.py
@@ -39,7 +39,7 @@ class StepWiseOptimizer(IOptimizer):
             **{**config.__dict__}
         )
 
-    def solve(self, preserve_percent: float = 0.0) -> OptimizerResult:
+    def solve(self, *, preserve_percent: float = 0.0) -> OptimizerResult:
         best_soln_value: list[F] = list()
         # Start with the initial value from the input variables, and stepwise refine solve
         if not self.config.optimize_whole_solution_deck:

--- a/src/optimizers/core/__init__.py
+++ b/src/optimizers/core/__init__.py
@@ -1,10 +1,12 @@
 from .types import af64, f64, ai64, i64, ab8, b8
-from .base import OptimizerResult, IOptimizerConfig
+from .base import OptimizerResult, IOptimizerConfig, BaseOptimizer, WrappedGoalFcn
 from .variables import InputVariable, InputVariables
 
 __all__ = [
     "IOptimizerConfig",
     "OptimizerResult",
+    "BaseOptimizer",
+    "WrappedGoalFcn",
     "InputVariable",
     "InputVariables",
     "af64",

--- a/src/optimizers/core/base.py
+++ b/src/optimizers/core/base.py
@@ -1,3 +1,4 @@
+import abc
 import os
 from typing import Literal, Optional, TypeVar, get_args, Callable, Union, Any
 from dataclasses import dataclass, fields
@@ -5,7 +6,7 @@ import numpy as np
 from joblib import cpu_count, Parallel
 from tqdm import trange, tqdm
 
-from .types import AF, F
+from .types import AF, AI, F
 from .samplers import SamplerType
 
 _TRUTHY = {"1", "true", "yes", "on"}
@@ -207,18 +208,25 @@ class IOptimizerConfig:
             self.joblib_prefer = "threads"
 
 
+# A solution is a real-valued decision vector for continuous solvers (GA/PSO/
+# ACO/GD), or a city permutation -- one tour (``AI``) or several (``list[AI]``,
+# e.g. one per vehicle/cluster in ``AntColonyMTSP``) -- for combinatorial ones.
+Solution = Union[AF, AI, "list[AI]"]
+SolutionHistory = Union[AF, "list[AF]"]
+
+
 @dataclass
 class OptimizerResult:
-    """Base class for optimizer results.
+    """Result returned by every solver's ``solve()`` -- continuous and combinatorial alike.
 
     Extended to include optional constraint violation information and an unconstrained-best result.
     """
 
     solution_score: F
     """The score of the best solution found by the optimizer (respecting deck ordering)."""
-    solution_vector: AF
+    solution_vector: Solution
     """The best solution found by the optimizer (respecting deck ordering)."""
-    solution_history: Optional[AF] = None
+    solution_history: Optional[SolutionHistory] = None
     """The history of the best solutions found by the optimizer."""
     stop_reason: StopReason = "none"
     """Whether the optimizer stopped early due to convergence criteria."""
@@ -273,3 +281,37 @@ class OptimizerResult:
             generations_completed=self.generations_completed
             + other.generations_completed,
         )
+
+
+class BaseOptimizer(abc.ABC):
+    """Shared contract for every solver in this library.
+
+    Both the continuous ``IOptimizer`` hierarchy (GA/PSO/ACO/GD searching a
+    real-valued decision vector) and the combinatorial ``TSPBase`` hierarchy
+    (GA/ACO/2-opt/3-opt/Lin-Kernighan searching over city permutations)
+    implement this: a ``config`` and a ``solve()`` that returns an
+    ``OptimizerResult``. That is as far as the two families are unified --
+    decision-variable handling, goal-function wrapping, and parallel
+    generation dispatch differ enough between "evaluate an arbitrary black-box
+    function" and "search over permutations of a distance matrix" that they
+    are not merged further; forcing one implementation over both would cost
+    readability without buying real sharing.
+    """
+
+    config: IOptimizerConfig
+
+    @abc.abstractmethod
+    def solve(self, *, preserve_percent: float = 0.0) -> OptimizerResult:
+        """Solve the given problem and return the best solution found.
+
+        ``preserve_percent`` is only meaningful for solvers whose initial
+        population can be partially seeded from an existing solution deck
+        (the continuous GA/PSO/ACO/GD family); solvers without that concept
+        (e.g. the combinatorial local-search/construction heuristics) accept
+        and ignore it. Every solver in the library exposes this same call
+        shape so callers can treat any of them polymorphically.
+        """
+        raise NotImplementedError("This method should be overridden by subclasses.")
+
+    def __str__(self) -> str:
+        return f"Solver(name={self.config.name})"

--- a/src/optimizers/solution_deck.py
+++ b/src/optimizers/solution_deck.py
@@ -5,11 +5,10 @@ import numpy as np
 import scipy
 from kmodes.kmodes import KModes
 
-from .core.base import ensure_literal_choice
-from .core.base import WrappedGoalFcn as WrappedGoalFcn  # re-exported
+from .core.base import ensure_literal_choice, WrappedGoalFcn
 from .core.random import get_seed
 from .core.types import f64, af64, ab8, b8
-from .core.variables import InputVariables as InputVariables  # re-exported
+from .core.variables import InputVariables
 from .core.samplers import SamplerType, create_sampler
 
 # Some type hinting

--- a/tests/test_combinatorics.py
+++ b/tests/test_combinatorics.py
@@ -103,8 +103,8 @@ def test_aco_mst():
         config=config, network_routes=distances, city_locations=all_cities
     )
     result = optimizer.solve()
-    plot_convergence(result.value_history)
-    plot_cities_and_route(all_cities, result.optimal_path)
+    plot_convergence(result.solution_history)
+    plot_cities_and_route(all_cities, result.solution_vector)
 
 
 def test_aco_tsp():
@@ -123,8 +123,8 @@ def test_aco_tsp():
         config=config, network_routes=distances, city_locations=all_cities
     )
     result = optimizer.solve()
-    plot_convergence(result.value_history)
-    plot_cities_and_route(all_cities, result.optimal_path)
+    plot_convergence(result.solution_history)
+    plot_cities_and_route(all_cities, result.solution_vector)
 
 
 def test_ga_tsp():
@@ -142,8 +142,8 @@ def test_ga_tsp():
         config=config, network_routes=distances, city_locations=all_cities
     )
     result = optimizer.solve()
-    plot_convergence(result.value_history)
-    plot_cities_and_route(all_cities, result.optimal_path)
+    plot_convergence(result.solution_history)
+    plot_cities_and_route(all_cities, result.solution_vector)
 
 
 def test_nn_tsp():
@@ -157,8 +157,8 @@ def test_nn_tsp():
     topt_config = TwoOptTSPConfig(name="2opt TSP", back_to_start=True)
     topt_optimizer = TwoOptTSP(
         config=topt_config,
-        initial_route=result.optimal_path,
-        initial_value=result.optimal_value,
+        initial_route=result.solution_vector,
+        initial_value=result.solution_score,
         network_routes=distances,
     )
     result2 = topt_optimizer.solve()
@@ -167,14 +167,14 @@ def test_nn_tsp():
     )
     topt_optimizer2 = ThreeOptTSP(
         config=topt_config2,
-        initial_route=result.optimal_path,
-        initial_value=result.optimal_value,
+        initial_route=result.solution_vector,
+        initial_value=result.solution_score,
         network_routes=distances,
     )
     result3 = topt_optimizer2.solve()
     plot_cities_and_route(
         all_cities,
-        [result.optimal_path, result2.optimal_path, result3.optimal_path],
+        [result.solution_vector, result2.solution_vector, result3.solution_vector],
     )
 
 
@@ -201,7 +201,7 @@ def test_ga_local_optimize_respects_back_to_start(back_to_start):
     )
     result = optimizer.solve()
 
-    path = np.asarray(result.optimal_path)
+    path = np.asarray(result.solution_vector)
     # Closed tours return depot-first AND depot-last (the return leg); the open
     # form omits the return leg. Strip it before checking the city set.
     cities = path[:-1] if back_to_start else path
@@ -209,7 +209,7 @@ def test_ga_local_optimize_respects_back_to_start(back_to_start):
     assert path[0] == 0
     # The reported value is measured with the run's own back_to_start setting.
     expected = check_path_distance(distances, path, back_to_start)
-    assert np.isclose(result.optimal_value, expected)
+    assert np.isclose(result.solution_score, expected)
 
 
 @pytest.mark.parametrize("back_to_start", [True, False])
@@ -232,12 +232,12 @@ def test_aco_local_optimize_respects_back_to_start(back_to_start):
     )
     result = optimizer.solve()
 
-    path = np.asarray(result.optimal_path)
+    path = np.asarray(result.solution_vector)
     cities = path[:-1] if back_to_start else path
     assert sorted(cities.tolist()) == list(range(distances.shape[0]))
     assert path[0] == 0
     expected = check_path_distance(distances, path, back_to_start)
-    assert np.isclose(result.optimal_value, expected)
+    assert np.isclose(result.solution_score, expected)
 
 
 def test_convex_hull_tsp():
@@ -246,7 +246,7 @@ def test_convex_hull_tsp():
     config = ConvexHullTSPConfig(name="Test Convex Hull", back_to_start=True)
     optimizer = ConvexHullTSP(config=config, city_locations=all_cities)
     result = optimizer.solve()
-    plot_cities_and_route(all_cities, result.optimal_path)
+    plot_cities_and_route(all_cities, result.solution_vector)
 
 
 def test_mtsp():
@@ -261,7 +261,7 @@ def test_mtsp():
         stop_after_iterations=5,
         local_optimize=True,
     )
-    optimizer = AntColonyMTSP(config, all_cities)
+    optimizer = AntColonyMTSP(config=config, city_locations=all_cities)
     result = optimizer.solve()
-    plot_convergence(result.value_history)
-    plot_cities_and_route(all_cities, result.optimal_path)
+    plot_convergence(result.solution_history)
+    plot_cities_and_route(all_cities, result.solution_vector)

--- a/tests/test_tsp_compare.py
+++ b/tests/test_tsp_compare.py
@@ -52,12 +52,12 @@ def test_lin_kernighan_valid_and_improves(seed):
     ).solve()
     lk = LinKernighanTSP(
         config=LinKernighanTSPConfig(name="lk"),
-        initial_route=nn.optimal_path.copy(),
-        initial_value=nn.optimal_value,
+        initial_route=nn.solution_vector.copy(),
+        initial_value=nn.solution_score,
         network_routes=D.copy(),
     ).solve()
-    assert _is_valid_tour(lk.optimal_path, 100)
-    assert lk.optimal_value <= nn.optimal_value  # never worse than the NN start
+    assert _is_valid_tour(lk.solution_vector, 100)
+    assert lk.solution_score <= nn.solution_score  # never worse than the NN start
 
 
 def test_lin_kernighan_from_scratch_builds_nn_start():
@@ -66,26 +66,26 @@ def test_lin_kernighan_from_scratch_builds_nn_start():
     lk = LinKernighanTSP(
         config=LinKernighanTSPConfig(name="lk"), network_routes=D.copy()
     ).solve()
-    assert _is_valid_tour(lk.optimal_path, 60)
+    assert _is_valid_tour(lk.solution_vector, 60)
 
 
 @pytest.mark.parametrize("seed", range(8))
 def test_lin_kernighan_reported_length_matches_tour(seed):
     # Regression: Or-opt can relocate the depot (city 0) off index 0. The
-    # reported optimal_value must equal the true closed-tour length recomputed
+    # reported solution_score must equal the true closed-tour length recomputed
     # independently — not overshoot by a spurious return-to-depot edge. (Seeds
     # 0 and 6 at N=40 are cases where the depot actually moves.)
     D = pairwise_distances(_cities(40, seed))
     lk = LinKernighanTSP(
         config=LinKernighanTSPConfig(name="lk"), network_routes=D.copy()
     ).solve()
-    path = lk.optimal_path
+    path = lk.solution_vector
     # Depot-first, consistent with the 2-opt/3-opt solvers.
     assert path[0] == 0
     cyc = path[:-1] if path[0] == path[-1] else path
     closed = np.append(cyc, cyc[0])
     true_len = float(D[closed[:-1], closed[1:]].sum())
-    assert np.isclose(lk.optimal_value, true_len)
+    assert np.isclose(lk.solution_score, true_len)
 
 
 # --------------------------- comparison report ---------------------------

--- a/tests/test_tsp_cython.py
+++ b/tests/test_tsp_cython.py
@@ -145,8 +145,8 @@ def test_solver_backend_parity(solver_cls, extra):
         config=NearestNeighborTSPConfig(name="nn"), network_routes=D.copy()
     ).solve()
     kw = dict(
-        initial_route=nn.optimal_path.copy(),
-        initial_value=nn.optimal_value,
+        initial_route=nn.solution_vector.copy(),
+        initial_value=nn.solution_score,
         network_routes=D.copy(),
     )
     r_nb = solver_cls(
@@ -155,8 +155,8 @@ def test_solver_backend_parity(solver_cls, extra):
     r_cy = solver_cls(
         config=TwoOptTSPConfig(name="x", local_search_backend="cython", **extra), **kw
     ).solve()
-    assert np.array_equal(r_nb.optimal_path, r_cy.optimal_path)
-    assert np.isclose(r_nb.optimal_value, r_cy.optimal_value)
+    assert np.array_equal(r_nb.solution_vector, r_cy.solution_vector)
+    assert np.isclose(r_nb.solution_score, r_cy.solution_score)
 
 
 # ------------------------------ performance ------------------------------
@@ -260,8 +260,8 @@ def test_lk_solver_backend_parity():
         config=NearestNeighborTSPConfig(name="nn"), network_routes=D.copy()
     ).solve()
     kw = dict(
-        initial_route=nn.optimal_path.copy(),
-        initial_value=nn.optimal_value,
+        initial_route=nn.solution_vector.copy(),
+        initial_value=nn.solution_score,
         network_routes=D.copy(),
     )
     r_nb = LinKernighanTSP(
@@ -270,8 +270,8 @@ def test_lk_solver_backend_parity():
     r_cy = LinKernighanTSP(
         config=LinKernighanTSPConfig(name="lk", local_search_backend="cython"), **kw
     ).solve()
-    assert np.array_equal(r_nb.optimal_path, r_cy.optimal_path)
-    assert np.isclose(r_nb.optimal_value, r_cy.optimal_value)
+    assert np.array_equal(r_nb.solution_vector, r_cy.solution_vector)
+    assert np.isclose(r_nb.solution_score, r_cy.solution_score)
 
 
 def test_lk_cython_vs_numba_benchmark(capsys):


### PR DESCRIPTION
## Summary

Ran the full test suite as a baseline (177 tests, mypy, flake8 all clean), then audited the public API surface for consistency and usability issues and fixed what was found:

- Added a shared `BaseOptimizer` ABC (`core/base.py`) that both the continuous `IOptimizer` hierarchy and the combinatorial `TSPBase` hierarchy implement, so every solver in the library shares the same `solve()` contract.
- Merged `CombinatoricsResult` into `OptimizerResult`: combinatorial solvers now return the same result type as continuous ones, with the same field names (`solution_vector`/`solution_score`/`solution_history`/`stop_reason`/`generations_completed`) instead of `optimal_path`/`optimal_value`/`value_history`.
- Unified every `solve()` signature to `solve(self, *, preserve_percent: float = 0.0) -> OptimizerResult`, including splitting `MultiTypeOptimizer`'s restart bookkeeping into a private helper so its public `solve()` matches everyone else's.
- Enforced keyword-only constructor args on `AntColonyMST` and `AntColonyMTSP` (the two combinatorial classes an earlier kwonly-args pass missed), and made `AntColonyMTSP` a proper `TSPBase` subclass.
- Moved `config` assignment into `TSPBase.__init__` so subclasses no longer repeat `self.config = config`.
- Canonicalized `InputVariables`/`WrappedGoalFcn` imports to `core`/`core.base` instead of the incidental `solution_deck` re-export path.
- Populated the previously-empty `continuous/__init__.py` and `combinatorial/__init__.py` with curated exports, and expanded the top-level `optimizers/__init__.py` to include the combinatorial and archive (MAP-Elites) classes, `SolutionDeck`, and several plot functions that were missing.
- Removed the always-broken `clustering_method="TSP"` option from `AntColonyMTSP` (it ran a full ACO pass and then unconditionally raised `ValueError`).
- Fixed `sample.py`'s broken `from src.optimizers import ...` and several stale positional constructor calls in `samples/tsp-demo.py` that would have raised `TypeError` against the current keyword-only API.
- Dropped dead leftover tuning-value comments on GA/ACO config defaults (e.g. `mutation_rate: float = 0.105  # 0.1`).
- Fixed a stale mypy `# type: ignore` and one flake8 unused-import surfaced while working through the refactor.

Not touched: `checkpoint.run_multiple`'s factory-based signature is a little indirect but not actually broken or inconsistent, so it was left as-is rather than widening scope further.

## Test plan

- [x] `pytest` — full suite, both `OPTIMIZERS_FAST=1` and full-fidelity workloads (177 passed)
- [x] `mypy -p optimizers` — clean, 0 errors
- [x] `flake8 ./src ./tests` — clean
- [x] Manually verified `import optimizers`, `import optimizers.continuous`, `import optimizers.combinatorial` all succeed with no circular-import issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C5i4ZRKUwB6DhANNpgj88f

---
_Generated by [Claude Code](https://claude.ai/code/session_01C5i4ZRKUwB6DhANNpgj88f)_