### PR TITLE
Bump numpy to >=2.4.6

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ readme = "README.md"
 requires-python = ">=3.10,<3.15"
 keywords = ["optimization", "GA", "PSO", "ACO", "GD"]
 dependencies = [
-    "numpy>=1.21",
+    "numpy>=2.4.6",
     "matplotlib>=3.10",
     "tqdm>=4.60",
     "joblib>=1.0",


### PR DESCRIPTION
## Summary
Bump numpy requirement from `>=1.21` to `>=2.4.6` to align with other submodules and ensure consistent NumPy 2.0+ compatibility across the optimization library ecosystem.

## Changes
- Updated `pyproject.toml` to require `numpy>=2.4.6` (was `>=1.21`)
- Aligns with `tribble-clustering` and `tribble-fis` requirements
- While `>=1.21` is technically compatible with 2.0+, explicit `>=2.4.6` ensures all dependent packages work together smoothly

## Context
This is part of the NumPy 2.0 migration for grad-school (issue fundthmcalculus/grad-school#105). Ensures all submodules use consistent minimum numpy versions.

---
_Generated by [Claude Code](https://claude.ai/code/session_01QDfPsaFjUVkLQAwFf5Mihw)_